### PR TITLE
Seaside and Intrigue unit tests

### DIFF
--- a/src/client/cards/seaside/Bazaar.jsx
+++ b/src/client/cards/seaside/Bazaar.jsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import Card from 'cards/Card';
+import Coin from 'components/Coin';
+
+export default class Bazaar extends Card {
+  static description = (
+    <div>
+      <div><strong>+1 Card</strong></div>
+      <div><strong>+2 Actions</strong></div>
+      <div>+<Coin>1</Coin></div>
+    </div>
+  );
+  static cost = <Coin>5</Coin>
+  static types = ['Action'];
+}
+
+Card.classes.set('Bazaar', Bazaar);

--- a/src/server/cards/intrigue/Mill.js
+++ b/src/server/cards/intrigue/Mill.js
@@ -22,8 +22,4 @@ export default class Mill extends Card {
       }
     }
   }
-  static getNumberInSupply(game) {
-    if (game.players.size === 2) return 8;
-    return 12;
-  }
 }

--- a/src/server/cards/intrigue/Replace.js
+++ b/src/server/cards/intrigue/Replace.js
@@ -4,7 +4,11 @@ export default class Replace extends Card {
   static cost = new Card.Cost({ coin: 5 });
   static types = new Set(['Action', 'Attack']);
   async onPlay(player, event) {
-    const [card] = await player.selectCards({ min: 1, max: 1, message: 'Select a card trash' });
+    const [card] = await player.selectCards({
+      min: 1,
+      max: 1,
+      message: 'Select a card trash'
+    });
     if (card) {
       await player.trash(card);
       const [supply] = await player.selectSupplies({
@@ -19,9 +23,9 @@ export default class Replace extends Card {
       if (supply) {
         const cardToGain = supply.cards.last();
         if (cardToGain.types.has('Action') || cardToGain.types.has('Treasure')) {
-          await player.gainSpecificCard(cardToGain, cardToGain.supply, player.deck);
+          await player.gain(cardToGain.title, player.deck);
         } else {
-          await player.gainSpecificCard(cardToGain, cardToGain.supply);
+          await player.gain(cardToGain.title);
         }
         if (cardToGain.types.has('Victory')) {
           await player.forEachOtherPlayer(other => {

--- a/src/server/cards/intrigue/SecretPassage.js
+++ b/src/server/cards/intrigue/SecretPassage.js
@@ -27,7 +27,7 @@ export default class SecretPassage extends Card {
     } else {
       const [pos] = res;
       player.hand.delete(card);
-      player.deck.splice(player.deck.map.get(pos.id), 0, card);
+      player.deck.splice(player.deck._map.get(pos.id), 0, card);
     }
 
   }

--- a/src/server/cards/intrigue/ShantyTown.js
+++ b/src/server/cards/intrigue/ShantyTown.js
@@ -5,7 +5,7 @@ export default class ShantyTown extends Card {
   static types = new Set(['Action']);
   async onPlay(player) {
     player.actions += 2;
-    player.game.log(`${player.name} reveals ${player.hand.list.map(c => c.title).join(', ')}`);
+    player.game.log(`${player.name} reveals ${player.hand.map(c => c.title).join(', ')}`);
     if (!player.hand.some(card => card.types.has('Action'))) {
       await player.draw(2);
     }

--- a/src/server/cards/intrigue/Upgrade.js
+++ b/src/server/cards/intrigue/Upgrade.js
@@ -14,7 +14,7 @@ export default class Upgrade extends Card {
         max: 1,
         predicate: s => (
           s.cards.size > 0 &&
-          player.costsEqualTo(s.cards.last(), { coin: card.cost.coin + 1 })
+          player.cardCostsEqualTo(s.cards.last(), { coin: card.cost.coin + 1 })
         ),
         message: 'Choose an card to gain'
       });

--- a/src/server/cards/intrigue/WishingWell.js
+++ b/src/server/cards/intrigue/WishingWell.js
@@ -14,9 +14,11 @@ export default class WishingWell extends Card {
     });
     player.game.log(`${player.name} names ${supply.title}`);
     const [card] = await player.lookAtTopOfDeck(1);
-    player.game.log(`${player.name} reveals ${card.title}`);
-    if (card && card.title === supply.title) {
-      await player.draw(1);
+    if (card) {
+      player.game.log(`${player.name} reveals ${card.title}`);
+      if (card && card.title === supply.title) {
+        await player.draw(1);
+      }
     }
   }
 }

--- a/src/server/cards/intrigueFirst/Saboteur.js
+++ b/src/server/cards/intrigueFirst/Saboteur.js
@@ -14,8 +14,10 @@ export default class Saboteur extends Card {
       let done = false;
       while ((done === false) && (other.deck.size + other.discardPile.size > 0)) {
         const [card] = await other.draw(1, false);
-        if (player.costsMoreThanEqualTo(card, { coin: 3 })) {
-          await other.trash(card, other.deck);
+        aside.push(card);
+        if (await player.cardCostsGreaterThanEqualTo(card, { coin: 3 })
+        && await player.cardCostsLessThanEqualTo(card, { coin: 6 })) {
+          await other.trash(card, aside);
           const [supply] = await other.selectSupplies({
             min: 1,
             max: 1,
@@ -27,8 +29,6 @@ export default class Saboteur extends Card {
           });
           if (supply) await other.gain(supply.title);
           done = true;
-        } else {
-          aside.push(card);
         }
       }
       while (aside.length > 0) {

--- a/src/server/cards/intrigueFirst/Scout.js
+++ b/src/server/cards/intrigueFirst/Scout.js
@@ -5,25 +5,19 @@ export default class Scout extends Card {
   static cost = new Card.Cost({ coin: 4 });
   static types = new Set(['Action']);
   async onPlay(player) {
-    const cardsInspected = new Pile();
     player.actions++;
-    const cards = player.lookAtTopOfDeck(4);
-    cards.forEach(c => {
-      if (c.types.has('Victory')) {
-        player.moveCard(c, player.deck, player.hand);
-      } else {
-        cardsInspected.push(c);
-      }
+    const cards = player.draw(4, false);
+    cards.filter(c => c.types.has('Victory')).forEach(c => {
+      player.moveCard(c, cards, player.hand);
     });
-    while (cardsInspected.size > 0) {
+    while (cards.size > 0) {
       const [card] = await player.selectCards({
         min: 1,
         max: 1,
-        pile: cardsInspected,
+        pile: cards,
         message: 'Select Card to put on top of deck'
       });
-      player.topDeck(card, player.deck);
-      cardsInspected.delete(card);
+      player.topDeck(card, cards);
     }
   }
 }

--- a/src/server/cards/intrigueFirst/SecretChamber.js
+++ b/src/server/cards/intrigueFirst/SecretChamber.js
@@ -24,13 +24,13 @@ export default class SecretChamber extends Card {
 
   async onTrigger(event, player) {
     await player.draw(2);
-    const cards = await player.selectCards({
-      min: 2,
-      max: 2,
-      message: 'Choose 2 cards to place on top of your deck',
-    });
-    for (let i = 0; i < cards.length; i++) {
-      await player.topDeck(cards[i]);
+    for (let i = 0; i < 2; i++) {
+      const [card] = await player.selectCards({
+        min: 1,
+        max: 1,
+        message: `Select ${i === 0 ? 'first' : 'second'} card to put on your deck`,
+      });
+      await player.topDeck(card);
     }
   }
 }

--- a/src/server/cards/seaside/Bazaar.js
+++ b/src/server/cards/seaside/Bazaar.js
@@ -1,0 +1,11 @@
+import Card from 'cards/Card';
+
+export default class Bazaar extends Card {
+  static cost = new Card.Cost({ coin: 5 });
+  static types = new Set(['Action']);
+  async onPlay(player) {
+    await player.draw(1);
+    player.actions += 2;
+    player.money++;
+  }
+}

--- a/src/server/cards/seaside/Cutpurse.js
+++ b/src/server/cards/seaside/Cutpurse.js
@@ -10,14 +10,9 @@ export default class Cutpurse extends Card {
         return;
       }
       if (other.hand.some(card => card.title === 'Copper')) {
-        for (let i = 0; i < other.hand.size; i++) {
-          if (other.hand.list[i].title === 'Copper') {
-            other.discard(other.hand.list[i]);
-            break;
-          }
-        }
+        await other.discard(other.hand.filter(card => card.title === 'Copper').last());
       } else {
-        // other.revealHand();
+        other.revealHand();
       }
     });
   }

--- a/src/server/cards/seaside/Embargo.js
+++ b/src/server/cards/seaside/Embargo.js
@@ -17,11 +17,12 @@ export default class Embargo extends Card {
       } else {
         supply.tokens.embargo = 1;
       }
+      player.game.log(`${player.name} adds an embargo token to the ${supply.title} supply: ${supply.tokens.embargo}`);
     }
   }
 
   willTriggerOn(event, player, persistent) {
-    return persistent === 'persistent' && event.triggeringPlayer === player && player.game.supplies.get(event.card.title).tokens.embargo > 0;
+    return persistent && event.triggeringPlayer === player && player.game.supplies.get(event.card.title).tokens.embargo > 0;
   }
 
   async onTrigger(event, player) {

--- a/src/server/cards/seaside/NativeVillage.js
+++ b/src/server/cards/seaside/NativeVillage.js
@@ -7,11 +7,11 @@ export default class NativeVillage extends Card {
   async onPlay(player) {
     player.actions += 2;
     const [card] = player.lookAtTopOfDeck(1);
+    const choice = await player.selectOption([
+      'Place on Native Village mat',
+      'Pick up entire mat into your hand'
+    ]);
     if (card) {
-      const choice = await player.selectOption([
-        'Place on Native Village mat',
-        'Pick up entire mat into your hand'
-      ]);
       switch (choice) {
         case 0:
           player.moveCard(card, player.deck, player.mats.nativeVillage);

--- a/src/server/cards/seaside/Navigator.js
+++ b/src/server/cards/seaside/Navigator.js
@@ -6,34 +6,28 @@ export default class Navigator extends Card {
   static types = new Set(['Action']);
   async onPlay(player) {
     player.money += 2;
-    const cards = await player.lookAtTopOfDeck(5);
+    const cards = await player.draw(5, false);
     const cardsStr = cards.map(c => c.title).join(', ');
 
     const choice = await player.selectOption(['Keep on top', 'Discard all five'], cardsStr);
     switch (choice) {
       case 0:
       {
-        const cardsInspected = new Pile();
-        for (let i = 0; i < cards.length; i++) {
-          cardsInspected.push(cards[i]);
-        }
-        console.log(cardsInspected);
-        console.log(player.deck);
-        while (cardsInspected.size > 0) {
+        while (cards.size > 1) {
           const [card] = await player.selectCards({
             min: 1,
             max: 1,
-            pile: cardsInspected,
+            pile: cards,
             message: 'Select Card to put on top of deck'
           });
-          player.topDeck(card, player.deck);
-          cardsInspected.delete(card);
+          player.topDeck(card, cards);
         }
+        player.topDeck(cards.last(), cards);
         break;
       }
       case 1:
-        for (let i = 0; i < cards.size; i++) {
-          await player.discard(cards[i], player.deck);
+        while (cards.length > 0) {
+          await player.discard(cards.last(), cards);
         }
         break;
       default:

--- a/src/server/cards/seaside/SeaHag.js
+++ b/src/server/cards/seaside/SeaHag.js
@@ -4,7 +4,7 @@ export default class SeaHag extends Card {
   static cost = new Card.Cost({ coin: 4 });
   static types = new Set(['Action', 'Attack']);
   async onPlay(player, event) {
-    player.forEachOtherPlayer(async other => {
+    await player.forEachOtherPlayer(async other => {
       if (event.handledByPlayer.get(other)) {
         return;
       }

--- a/src/server/cards/seaside/TreasureMap.js
+++ b/src/server/cards/seaside/TreasureMap.js
@@ -5,7 +5,7 @@ export default class TreasureMap extends Card {
   static types = new Set(['Action', 'Attack']);
   async onPlay(player) {
     player.trash(this, player.playArea);
-    const otherCard = player.hand.list.find(c => c.title === 'TreasureMap');
+    const otherCard = player.hand.find(c => c.title === 'TreasureMap');
     if (otherCard) {
       player.trash(otherCard);
       for (let i = 0; i < 4; i++) {

--- a/src/server/cards/seaside/Treasury.js
+++ b/src/server/cards/seaside/Treasury.js
@@ -9,7 +9,7 @@ export default class Treasury extends Card {
     player.money++;
   }
 
-  willTriggerOn(event, player) {
+  canTriggerOn(event, player) {
     return (
       event.name === 'discard' &&
       event.triggeringPlayer === player &&

--- a/src/server/models/Player.js
+++ b/src/server/models/Player.js
@@ -537,6 +537,9 @@ export default class Player extends Model {
     while (this.playArea.size > 0) {
       this.moveCard(this.playArea.last(), this.playArea, this.deck);
     }
+    while (this.asidePile.size > 0) {
+      this.moveCard(this.asidePile.last(), this.asidePile, this.deck);
+    }
     while (this.discardPile.size > 0) {
       this.moveCard(this.discardPile.last(), this.discardPile, this.deck);
     }

--- a/src/server/utils/Pile.js
+++ b/src/server/utils/Pile.js
@@ -126,8 +126,8 @@ export default class Pile extends Model {
   }
 
   first() {
-    if (this.list.length === 0) return null;
-    return this.list[0];
+    if (this._list.length === 0) return null;
+    return this._list[0];
   }
 
   last() {

--- a/src/tests/server/cards/cornucopia/YoungWitch.js
+++ b/src/tests/server/cards/cornucopia/YoungWitch.js
@@ -21,6 +21,7 @@ export default () => {
     await waitForNextInput();
     expect(player.hand.length).toBe(4);
     expect(otherPlayer.discardPile.last().title).toBe('Curse');
+    expect(game.supplies.get(YoungWitch.bane.title).cards.length).toBe(10);
   });
 
   test('should be blocked by bane', async () => {
@@ -43,6 +44,8 @@ export default () => {
 
     expect(otherPlayer.hand.length).toBe(5);
   });
+
+  test('a spilt pile bane should work for all cards in the pile');
 
   test('should be blocked by Moat', async () => {
     const player = await startGameGetPlayerAndWaitForStartOfTurn(game);

--- a/src/tests/server/cards/intrigue/Baron.js
+++ b/src/tests/server/cards/intrigue/Baron.js
@@ -1,0 +1,53 @@
+import { test, beforeEach, expect } from '../../testingFramework';
+import { createGame, setHand, respondWithCard, respondWithNoCards, startGameGetPlayerAndWaitForStartOfTurn, waitForNextInput } from '../../toolbox';
+
+export default () => {
+  let game;
+
+  beforeEach(async () => {
+    game = await createGame();
+    game.getKingdomCards = () => ['Baron'];
+  });
+
+  test('should allow discarding of Estates for money', async () => {
+    const player = await startGameGetPlayerAndWaitForStartOfTurn(game);
+    setHand(player, ['Copper', 'Estate', 'Copper', 'Copper', 'Baron']);
+    await waitForNextInput();
+    respondWithCard('Baron');
+    await waitForNextInput();
+    respondWithCard('Estate');
+    await waitForNextInput();
+    expect(player.hand.length).toBe(3);
+    expect(player.actions).toBe(0);
+    expect(player.buys).toBe(2);
+    expect(player.money).toBe(4);
+  });
+
+  test('should gain estate if none in hand', async () => {
+    const player = await startGameGetPlayerAndWaitForStartOfTurn(game);
+    setHand(player, ['Copper', 'Copper', 'Copper', 'Copper', 'Baron']);
+    await waitForNextInput();
+    respondWithCard('Baron');
+    await waitForNextInput();
+    expect(player.hand.length).toBe(4);
+    expect(player.actions).toBe(0);
+    expect(player.buys).toBe(2);
+    expect(player.money).toBe(0);
+    expect(player.discardPile.last().title).toBe('Estate');
+  });
+
+  test('should gain estate if none in hand', async () => {
+    const player = await startGameGetPlayerAndWaitForStartOfTurn(game);
+    setHand(player, ['Copper', 'Estate', 'Copper', 'Copper', 'Baron']);
+    await waitForNextInput();
+    respondWithCard('Baron');
+    await waitForNextInput();
+    respondWithNoCards();
+    await waitForNextInput();
+    expect(player.hand.length).toBe(4);
+    expect(player.actions).toBe(0);
+    expect(player.buys).toBe(2);
+    expect(player.money).toBe(0);
+    expect(player.discardPile.last().title).toBe('Estate');
+  });
+};

--- a/src/tests/server/cards/intrigue/Conspirator.js
+++ b/src/tests/server/cards/intrigue/Conspirator.js
@@ -1,0 +1,43 @@
+import { test, beforeEach, expect } from '../../testingFramework';
+import { createGame, setHand, respondWithCard, startGameGetPlayerAndWaitForStartOfTurn, waitForNextInput } from '../../toolbox';
+
+export default () => {
+  let game;
+
+  beforeEach(async () => {
+    game = await createGame();
+    game.getKingdomCards = () => ['Conspirator'];
+  });
+
+  test('should give $2 when cast by its self', async () => {
+    const player = await startGameGetPlayerAndWaitForStartOfTurn(game);
+    setHand(player, ['Copper', 'Copper', 'Copper', 'Copper', 'Conspirator']);
+    await waitForNextInput();
+    respondWithCard('Conspirator');
+    await waitForNextInput();
+    expect(player.hand.length).toBe(4);
+    expect(player.actions).toBe(0);
+    expect(player.money).toBe(2);
+  });
+
+  test('should give cantrip on third cast', async () => {
+    const player = await startGameGetPlayerAndWaitForStartOfTurn(game);
+    setHand(player, ['Copper', 'Copper', 'Village', 'Conspirator', 'Conspirator']);
+    await waitForNextInput();
+    respondWithCard('Village');
+    await waitForNextInput();
+    expect(player.hand.length).toBe(5);
+    expect(player.actions).toBe(2);
+    expect(player.money).toBe(0);
+    respondWithCard('Conspirator');
+    await waitForNextInput();
+    expect(player.hand.length).toBe(4);
+    expect(player.actions).toBe(1);
+    expect(player.money).toBe(2);
+    respondWithCard('Conspirator');
+    await waitForNextInput();
+    expect(player.hand.length).toBe(4);
+    expect(player.actions).toBe(1);
+    expect(player.money).toBe(4);
+  });
+};

--- a/src/tests/server/cards/intrigue/Coppersmith.js
+++ b/src/tests/server/cards/intrigue/Coppersmith.js
@@ -1,0 +1,43 @@
+import { test, beforeEach, expect } from '../../testingFramework';
+import { createGame, setHand, respondWithCard, startGameGetPlayerAndWaitForStartOfTurn, waitForNextInput } from '../../toolbox';
+
+export default () => {
+  let game;
+
+  beforeEach(async () => {
+    game = await createGame();
+    game.getKingdomCards = () => ['Coppersmith'];
+  });
+
+  test('copper should produce $2', async () => {
+    const player = await startGameGetPlayerAndWaitForStartOfTurn(game);
+    setHand(player, ['Copper', 'Copper', 'Copper', 'Copper', 'Coppersmith']);
+    await waitForNextInput();
+    respondWithCard('Coppersmith');
+    await waitForNextInput();
+    respondWithCard('Copper');
+    await waitForNextInput();
+    expect(player.money).toBe(2);
+    respondWithCard('Copper');
+    await waitForNextInput();
+    expect(player.money).toBe(4);
+  });
+
+  test('copper should produce $3', async () => {
+    const player = await startGameGetPlayerAndWaitForStartOfTurn(game);
+    setHand(player, ['Copper', 'Copper', 'Village', 'Coppersmith', 'Coppersmith']);
+    await waitForNextInput();
+    respondWithCard('Village');
+    await waitForNextInput();
+    respondWithCard('Coppersmith');
+    await waitForNextInput();
+    respondWithCard('Coppersmith');
+    await waitForNextInput();
+    respondWithCard('Copper');
+    await waitForNextInput();
+    expect(player.money).toBe(3);
+    respondWithCard('Copper');
+    await waitForNextInput();
+    expect(player.money).toBe(6);
+  });
+};

--- a/src/tests/server/cards/intrigue/Courtier.js
+++ b/src/tests/server/cards/intrigue/Courtier.js
@@ -1,0 +1,49 @@
+import { test, beforeEach, expect } from '../../testingFramework';
+import { createGame, setHand, respondWithCard, respondWithChoice, startGameGetPlayerAndWaitForStartOfTurn, waitForNextInput } from '../../toolbox';
+
+export default () => {
+  let game;
+
+  beforeEach(async () => {
+    game = await createGame();
+    game.getKingdomCards = () => ['Courtier'];
+  });
+
+  test('should give money and gold', async () => {
+    const player = await startGameGetPlayerAndWaitForStartOfTurn(game);
+    setHand(player, ['Copper', 'Copper', 'Copper', 'Island', 'Courtier']);
+    await waitForNextInput();
+    respondWithCard('Courtier');
+    await waitForNextInput();
+    respondWithCard('Island');
+    await waitForNextInput();
+    respondWithChoice(3);
+    await waitForNextInput();
+    respondWithChoice(2);
+    await waitForNextInput();
+    expect(player.actions).toBe(0);
+    expect(player.buys).toBe(1);
+    expect(player.discardPile.last().title).toBe('Gold');
+    expect(player.money).toBe(3);
+  });
+
+  test('should give action and buy', async () => {
+    const player = await startGameGetPlayerAndWaitForStartOfTurn(game);
+    setHand(player, ['Copper', 'Copper', 'Copper', 'Island', 'Courtier']);
+    await waitForNextInput();
+    respondWithCard('Courtier');
+    await waitForNextInput();
+    respondWithCard('Island');
+    await waitForNextInput();
+    respondWithChoice(0);
+    await waitForNextInput();
+    respondWithChoice(0);
+    await waitForNextInput();
+    expect(player.actions).toBe(1);
+    expect(player.buys).toBe(2);
+    expect(player.money).toBe(0);
+  });
+
+  test('should love Dame Josephine');
+
+};

--- a/src/tests/server/cards/intrigue/Courtyard.js
+++ b/src/tests/server/cards/intrigue/Courtyard.js
@@ -1,0 +1,37 @@
+import { test, beforeEach, expect } from '../../testingFramework';
+import { createGame, setHand, setDeck, respondWithCard, startGameGetPlayerAndWaitForStartOfTurn, waitForNextInput } from '../../toolbox';
+
+export default () => {
+  let game;
+
+  beforeEach(async () => {
+    game = await createGame();
+    game.getKingdomCards = () => ['Courtyard'];
+  });
+
+  test('draws 3 puts one back', async () => {
+    const player = await startGameGetPlayerAndWaitForStartOfTurn(game);
+    setHand(player, ['Copper', 'Copper', 'Copper', 'Copper', 'Courtyard']);
+    setDeck(player, ['Silver', 'Gold', 'Silver', 'Silver']);
+    await waitForNextInput();
+    respondWithCard('Courtyard');
+    await waitForNextInput();
+    respondWithCard('Gold');
+    await waitForNextInput();
+    expect(player.hand.length).toBe(6);
+    expect(player.deck.last().title).toBe('Gold');
+  });
+
+  test('wroks with empty deck', async () => {
+    const player = await startGameGetPlayerAndWaitForStartOfTurn(game);
+    setHand(player, ['Gold', 'Copper', 'Copper', 'Copper', 'Courtyard']);
+    setDeck(player, []);
+    await waitForNextInput();
+    respondWithCard('Courtyard');
+    await waitForNextInput();
+    respondWithCard('Gold');
+    await waitForNextInput();
+    expect(player.hand.length).toBe(3);
+    expect(player.deck.last().title).toBe('Gold');
+  });
+};

--- a/src/tests/server/cards/intrigue/Diplomat.js
+++ b/src/tests/server/cards/intrigue/Diplomat.js
@@ -1,0 +1,56 @@
+import { test, beforeEach, expect } from '../../testingFramework';
+import { createGame, setHand, setDeck, respondWithCard, respondWithCards, respondWithChoice, startGameGetPlayerAndWaitForStartOfTurn, waitForNextInput } from '../../toolbox';
+
+export default () => {
+  let game;
+
+  beforeEach(async () => {
+    game = await createGame();
+    game.getKingdomCards = () => ['Diplomat'];
+  });
+
+  test('should only draw with 5 card in cand', async () => {
+    const player = await startGameGetPlayerAndWaitForStartOfTurn(game);
+    setHand(player, ['Copper', 'Copper', 'Copper', 'Copper', 'Diplomat']);
+    await waitForNextInput();
+    respondWithCard('Diplomat');
+    await waitForNextInput();
+    expect(player.hand.length).toBe(6);
+    expect(player.actions).toBe(0);
+  });
+
+  test('should draw and give actions if less cards in hand', async () => {
+    const player = await startGameGetPlayerAndWaitForStartOfTurn(game);
+    setHand(player, ['Copper', 'Copper', 'Copper', 'Lurker', 'Diplomat']);
+    await waitForNextInput();
+    respondWithCard('Lurker');
+    await waitForNextInput();
+    respondWithChoice(1);
+    await waitForNextInput();
+    respondWithCard('Diplomat');
+    await waitForNextInput();
+    expect(player.hand.length).toBe(5);
+    expect(player.actions).toBe(2);
+  });
+
+  test('should react to attacks', async () => {
+    const player = await startGameGetPlayerAndWaitForStartOfTurn(game);
+    setHand(player, ['Copper', 'Copper', 'Copper', 'Copper', 'Militia']);
+    const otherPlayer = game.playerOrder.find(p => p !== player);
+    setHand(otherPlayer, ['Copper', 'Copper', 'Copper', 'Copper', 'Diplomat']);
+    setDeck(otherPlayer, ['Copper', 'Copper', 'Copper', 'Estate', 'Estate']);
+    await waitForNextInput();
+    respondWithCard('Militia');
+    await waitForNextInput();
+    respondWithCard('Diplomat');
+    await waitForNextInput();
+    expect(otherPlayer.hand.length).toBe(7);
+    respondWithCards(['Estate', 'Estate', 'Copper']);
+    await waitForNextInput();
+    expect(otherPlayer.hand.length).toBe(4);
+    respondWithCards(['Copper']);
+    await waitForNextInput();
+    expect(otherPlayer.hand.length).toBe(3);
+    expect(player.money).toBe(2);
+  });
+};

--- a/src/tests/server/cards/intrigue/Duke.js
+++ b/src/tests/server/cards/intrigue/Duke.js
@@ -1,0 +1,38 @@
+import { test, beforeEach, expect } from '../../testingFramework';
+import { createGame, setHand, setDeck, startGameGetPlayerAndWaitForStartOfTurn, waitForNextInput } from '../../toolbox';
+
+export default () => {
+  let game;
+
+  beforeEach(async () => {
+    game = await createGame();
+    game.getKingdomCards = () => ['Duke'];
+  });
+
+  test('Duke should be worth 0', async () => {
+    const player = await startGameGetPlayerAndWaitForStartOfTurn(game);
+    setHand(player, ['Copper', 'Copper', 'Copper', 'Copper', 'Duke']);
+    setDeck(player, ['Copper', 'Copper', 'Copper', 'Copper', 'Copper']);
+    await waitForNextInput();
+    game.endOfGame();
+    expect(player.score).toBe(0);
+  });
+
+  test('Duke should be worth 3', async () => {
+    const player = await startGameGetPlayerAndWaitForStartOfTurn(game);
+    setHand(player, ['Duchy', 'Copper', 'Copper', 'Copper', 'Duke']);
+    setDeck(player, ['Copper', 'Copper', 'Duchy', 'Copper', 'Duchy']);
+    await waitForNextInput();
+    game.endOfGame();
+    expect(player.score).toBe(12);
+  });
+
+  test('Duke should be worth 5', async () => {
+    const player = await startGameGetPlayerAndWaitForStartOfTurn(game);
+    setHand(player, ['Copper', 'Duchy', 'Copper', 'Duchy', 'Duke']);
+    setDeck(player, ['Duchy', 'Copper', 'Duchy', 'Copper', 'Duchy']);
+    await waitForNextInput();
+    game.endOfGame();
+    expect(player.score).toBe(20);
+  });
+};

--- a/src/tests/server/cards/intrigue/GreatHall.js
+++ b/src/tests/server/cards/intrigue/GreatHall.js
@@ -1,0 +1,31 @@
+import { test, beforeEach, expect } from '../../testingFramework';
+import { createGame, setHand, setDeck, respondWithCard, startGameGetPlayerAndWaitForStartOfTurn, waitForNextInput } from '../../toolbox';
+
+export default () => {
+  let game;
+
+  beforeEach(async () => {
+    game = await createGame();
+    game.getKingdomCards = () => ['GreatHall'];
+  });
+
+  test('should cantrip', async () => {
+    const player = await startGameGetPlayerAndWaitForStartOfTurn(game);
+    setHand(player, ['Copper', 'Copper', 'Copper', 'Copper', 'GreatHall']);
+    await waitForNextInput();
+    respondWithCard('GreatHall');
+    await waitForNextInput();
+    expect(player.hand.length).toBe(5);
+    expect(player.actions).toBe(1);
+  });
+
+  test('should be worth one VP at end of game', async () => {
+    const player = await startGameGetPlayerAndWaitForStartOfTurn(game);
+    setHand(player, ['Copper', 'Copper', 'Copper', 'Copper', 'GreatHall']);
+    setDeck(player, ['Copper', 'Copper', 'Copper', 'Copper', 'Copper']);
+    await waitForNextInput();
+    await waitForNextInput();
+    game.endOfGame();
+    expect(player.score).toBe(1);
+  });
+};

--- a/src/tests/server/cards/intrigue/Harem.js
+++ b/src/tests/server/cards/intrigue/Harem.js
@@ -1,0 +1,29 @@
+import { test, beforeEach, expect } from '../../testingFramework';
+import { createGame, setHand, setDeck, respondWithCard, startGameGetPlayerAndWaitForStartOfTurn, waitForNextInput } from '../../toolbox';
+
+export default () => {
+  let game;
+
+  beforeEach(async () => {
+    game = await createGame();
+    game.getKingdomCards = () => ['Harem'];
+  });
+
+  test('should give $2', async () => {
+    const player = await startGameGetPlayerAndWaitForStartOfTurn(game);
+    setHand(player, ['Copper', 'Copper', 'Copper', 'Copper', 'Harem']);
+    await waitForNextInput();
+    respondWithCard('Harem');
+    await waitForNextInput();
+    expect(player.money).toBe(2);
+  });
+
+  test('should be worth 2', async () => {
+    const player = await startGameGetPlayerAndWaitForStartOfTurn(game);
+    setHand(player, ['Copper', 'Copper', 'Copper', 'Copper', 'Harem']);
+    setDeck(player, ['Copper', 'Copper', 'Copper', 'Copper', 'Copper']);
+    await waitForNextInput();
+    game.endOfGame();
+    expect(player.score).toBe(2);
+  });
+};

--- a/src/tests/server/cards/intrigue/Ironworks.js
+++ b/src/tests/server/cards/intrigue/Ironworks.js
@@ -1,0 +1,106 @@
+import { test, beforeEach, expect } from '../../testingFramework';
+import { createGame, setHand, respondWithCard, respondWithSupply, startGameGetPlayerAndWaitForStartOfTurn, waitForNextInput } from '../../toolbox';
+
+export default () => {
+  let game;
+
+  beforeEach(async () => {
+    game = await createGame();
+    game.getKingdomCards = () => ['Ironworks', 'Island', 'Harem'];
+  });
+
+  test('should work on actions', async () => {
+    const player = await startGameGetPlayerAndWaitForStartOfTurn(game);
+    setHand(player, ['Copper', 'Copper', 'Copper', 'Copper', 'Ironworks']);
+    await waitForNextInput();
+    respondWithCard('Ironworks');
+    await waitForNextInput();
+    respondWithSupply('Ironworks');
+    await waitForNextInput();
+    expect(player.hand.length).toBe(4);
+    expect(player.actions).toBe(1);
+    expect(player.money).toBe(0);
+    expect(player.discardPile.last().title).toBe('Ironworks');
+  });
+
+  test('should work on treasures', async () => {
+    const player = await startGameGetPlayerAndWaitForStartOfTurn(game);
+    setHand(player, ['Copper', 'Copper', 'Copper', 'Copper', 'Ironworks']);
+    await waitForNextInput();
+    respondWithCard('Ironworks');
+    await waitForNextInput();
+    respondWithSupply('Silver');
+    await waitForNextInput();
+    expect(player.hand.length).toBe(4);
+    expect(player.actions).toBe(0);
+    expect(player.money).toBe(1);
+    expect(player.discardPile.last().title).toBe('Silver');
+  });
+
+  test('should work on Victory cards', async () => {
+    const player = await startGameGetPlayerAndWaitForStartOfTurn(game);
+    setHand(player, ['Copper', 'Copper', 'Copper', 'Copper', 'Ironworks']);
+    await waitForNextInput();
+    respondWithCard('Ironworks');
+    await waitForNextInput();
+    respondWithSupply('Estate');
+    await waitForNextInput();
+    expect(player.hand.length).toBe(5);
+    expect(player.actions).toBe(0);
+    expect(player.money).toBe(0);
+    expect(player.discardPile.last().title).toBe('Estate');
+  });
+
+  test('should work on Curses', async () => {
+    const player = await startGameGetPlayerAndWaitForStartOfTurn(game);
+    setHand(player, ['Copper', 'Copper', 'Copper', 'Copper', 'Ironworks']);
+    await waitForNextInput();
+    respondWithCard('Ironworks');
+    await waitForNextInput();
+    respondWithSupply('Curse');
+    await waitForNextInput();
+    expect(player.hand.length).toBe(4);
+    expect(player.actions).toBe(0);
+    expect(player.money).toBe(0);
+    expect(player.discardPile.last().title).toBe('Curse');
+  });
+
+  test('should work on Action/Victory cards', async () => {
+    const player = await startGameGetPlayerAndWaitForStartOfTurn(game);
+    setHand(player, ['Copper', 'Copper', 'Copper', 'Copper', 'Ironworks']);
+    await waitForNextInput();
+    respondWithCard('Ironworks');
+    await waitForNextInput();
+    respondWithSupply('Island');
+    await waitForNextInput();
+    expect(player.hand.length).toBe(5);
+    expect(player.actions).toBe(1);
+    expect(player.money).toBe(0);
+    expect(player.discardPile.last().title).toBe('Island');
+  });
+
+  test('should work on Treasure/Victory cards', async () => {
+    const player = await startGameGetPlayerAndWaitForStartOfTurn(game);
+    setHand(player, ['Village', 'Village', 'Bridge', 'Bridge', 'Ironworks']);
+    await waitForNextInput();
+    respondWithCard('Village');
+    await waitForNextInput();
+    respondWithCard('Village');
+    await waitForNextInput();
+    respondWithCard('Bridge');
+    await waitForNextInput();
+    respondWithCard('Bridge');
+    await waitForNextInput();
+    expect(player.hand.length).toBe(3);
+    expect(player.actions).toBe(1);
+    expect(player.money).toBe(2);
+    respondWithCard('Ironworks');
+    await waitForNextInput();
+    respondWithSupply('Harem');
+    await waitForNextInput();
+    expect(player.hand.length).toBe(3);
+    expect(player.actions).toBe(0);
+    expect(player.money).toBe(3);
+    expect(player.discardPile.last().title).toBe('Harem');
+  });
+};

--- a/src/tests/server/cards/intrigue/Lurker.js
+++ b/src/tests/server/cards/intrigue/Lurker.js
@@ -1,0 +1,49 @@
+import { test, beforeEach, expect } from '../../testingFramework';
+import { createGame, setHand, respondWithCard, respondWithSupply, respondWithChoice, startGameGetPlayerAndWaitForStartOfTurn, waitForNextInput } from '../../toolbox';
+
+export default () => {
+  let game;
+
+  beforeEach(async () => {
+    game = await createGame();
+    game.getKingdomCards = () => ['Lurker', 'Market'];
+  });
+
+  test('should be able to trash and gain', async () => {
+    const player = await startGameGetPlayerAndWaitForStartOfTurn(game);
+    setHand(player, ['Copper', 'Copper', 'Copper', 'Lurker', 'Lurker']);
+    await waitForNextInput();
+    respondWithCard('Lurker');
+    await waitForNextInput();
+    respondWithChoice(0);
+    await waitForNextInput();
+    respondWithSupply('Market');
+    await waitForNextInput();
+    expect(player.actions).toBe(1);
+    expect(game.trash.last().title).toBe('Market');
+    expect(game.supplies.get('Market').cards.length).toBe(9);
+    respondWithCard('Lurker');
+    await waitForNextInput();
+    respondWithChoice(1);
+    await waitForNextInput();
+    respondWithCard('Market');
+    await waitForNextInput();
+    expect(game.trash.length).toBe(0);
+    expect(player.discardPile.last().title).toBe('Market');
+  });
+
+  test('doesn\'t fail with empty trash', async () => {
+    const player = await startGameGetPlayerAndWaitForStartOfTurn(game);
+    setHand(player, ['Copper', 'Copper', 'Copper', 'Copper', 'Lurker']);
+    await waitForNextInput();
+    respondWithCard('Lurker');
+    await waitForNextInput();
+    respondWithChoice(1);
+    await waitForNextInput();
+    respondWithCard('Copper');
+    await waitForNextInput();
+    expect(player.actions).toBe(1);
+    expect(game.trash.length).toBe(0);
+    expect(player.money).toBe(1);
+  });
+};

--- a/src/tests/server/cards/intrigue/Masquerade.js
+++ b/src/tests/server/cards/intrigue/Masquerade.js
@@ -1,0 +1,29 @@
+import { test, beforeEach, expect } from '../../testingFramework';
+import { createGame, setHand, respondWithCard, startGameGetPlayerAndWaitForStartOfTurn, waitForNextInput } from '../../toolbox';
+
+export default () => {
+  let game;
+
+  beforeEach(async () => {
+    game = await createGame();
+    game.getKingdomCards = () => ['Masquerade'];
+  });
+
+  test('should pass cards and trash', async () => {
+    const player = await startGameGetPlayerAndWaitForStartOfTurn(game);
+    setHand(player, ['Copper', 'Copper', 'Copper', 'Curse', 'Masquerade']);
+    const otherPlayer = game.playerOrder.find(p => p !== player);
+    setHand(otherPlayer, ['Copper', 'Copper', 'Copper', 'Copper', 'Estate']);
+    await waitForNextInput();
+    respondWithCard('Masquerade');
+    await waitForNextInput();
+    respondWithCard('Copper');
+    await waitForNextInput();
+    respondWithCard('Copper');
+    await waitForNextInput();
+    respondWithCard('Curse');
+    await waitForNextInput();
+    expect(player.hand.length).toBe(5);
+    expect(game.trash.last().title).toBe('Curse');
+  });
+};

--- a/src/tests/server/cards/intrigue/Mill.js
+++ b/src/tests/server/cards/intrigue/Mill.js
@@ -1,0 +1,64 @@
+import { test, beforeEach, expect } from '../../testingFramework';
+import { createGame, setHand, setDeck, respondWithCard, respondWithCards, respondWithChoice, startGameGetPlayerAndWaitForStartOfTurn, waitForNextInput } from '../../toolbox';
+
+export default () => {
+  let game;
+
+  beforeEach(async () => {
+    game = await createGame();
+    game.getKingdomCards = () => ['Mill'];
+  });
+
+  test('should cantrip', async () => {
+    const player = await startGameGetPlayerAndWaitForStartOfTurn(game);
+    setHand(player, ['Copper', 'Copper', 'Copper', 'Copper', 'Mill']);
+    await waitForNextInput();
+    respondWithCard('Mill');
+    await waitForNextInput();
+    expect(player.hand.length).toBe(5);
+    expect(player.actions).toBe(1);
+  });
+
+  test('should allow discard for money', async () => {
+    const player = await startGameGetPlayerAndWaitForStartOfTurn(game);
+    setHand(player, ['Copper', 'Copper', 'Copper', 'Copper', 'Mill']);
+    await waitForNextInput();
+    respondWithCard('Mill');
+    await waitForNextInput();
+    respondWithChoice(0);
+    await waitForNextInput();
+    respondWithCards(['Copper', 'Copper']);
+    await waitForNextInput();
+    expect(player.hand.length).toBe(3);
+    expect(player.actions).toBe(1);
+    expect(player.money).toBe(2);
+    expect(player.discardPile.length).toBe(2);
+  });
+
+  test('need to discard to get money', async () => {
+    const player = await startGameGetPlayerAndWaitForStartOfTurn(game);
+    setHand(player, ['Mill']);
+    setDeck(player, ['Copper']);
+    await waitForNextInput();
+    respondWithCard('Mill');
+    await waitForNextInput();
+    respondWithChoice(0);
+    await waitForNextInput();
+    respondWithCards(['Copper']);
+    await waitForNextInput();
+    expect(player.hand.length).toBe(0);
+    expect(player.actions).toBe(1);
+    expect(player.money).toBe(0);
+    expect(player.discardPile.length).toBe(1);
+  });
+
+  test('should be worth one VP at end of game', async () => {
+    const player = await startGameGetPlayerAndWaitForStartOfTurn(game);
+    setHand(player, ['Copper', 'Copper', 'Copper', 'Copper', 'Mill']);
+    setDeck(player, ['Copper', 'Copper', 'Copper', 'Copper', 'Copper']);
+    await waitForNextInput();
+    await waitForNextInput();
+    game.endOfGame();
+    expect(player.score).toBe(1);
+  });
+};

--- a/src/tests/server/cards/intrigue/MiningVillage.js
+++ b/src/tests/server/cards/intrigue/MiningVillage.js
@@ -1,0 +1,36 @@
+import { test, beforeEach, expect } from '../../testingFramework';
+import { createGame, setHand, respondWithCard, respondWithChoice, startGameGetPlayerAndWaitForStartOfTurn, waitForNextInput } from '../../toolbox';
+
+export default () => {
+  let game;
+
+  beforeEach(async () => {
+    game = await createGame();
+    game.getKingdomCards = () => ['MiningVillage'];
+  });
+
+  test('should act as a village', async () => {
+    const player = await startGameGetPlayerAndWaitForStartOfTurn(game);
+    setHand(player, ['Copper', 'Copper', 'Copper', 'Copper', 'MiningVillage']);
+    await waitForNextInput();
+    respondWithCard('MiningVillage');
+    await waitForNextInput();
+    expect(player.hand.length).toBe(5);
+    expect(player.actions).toBe(2);
+  });
+
+  test('should allow trashing for money', async () => {
+    const player = await startGameGetPlayerAndWaitForStartOfTurn(game);
+    setHand(player, ['Copper', 'Copper', 'Copper', 'Copper', 'MiningVillage']);
+    await waitForNextInput();
+    respondWithCard('MiningVillage');
+    await waitForNextInput();
+    respondWithChoice(0);
+    await waitForNextInput();
+    expect(player.hand.length).toBe(5);
+    expect(player.actions).toBe(2);
+    expect(player.money).toBe(2);
+    expect(player.playArea.length).toBe(0);
+    expect(game.trash.last().title).toBe('MiningVillage');
+  });
+};

--- a/src/tests/server/cards/intrigue/Minion.js
+++ b/src/tests/server/cards/intrigue/Minion.js
@@ -1,0 +1,71 @@
+import { test, beforeEach, expect } from '../../testingFramework';
+import { createGame, setHand, setDeck, respondWithCard, respondWithChoice, startGameGetPlayerAndWaitForStartOfTurn, waitForNextInput } from '../../toolbox';
+
+export default () => {
+  let game;
+
+  beforeEach(async () => {
+    game = await createGame();
+    game.getKingdomCards = () => ['Minion'];
+  });
+
+  test('should give $2', async () => {
+    const player = await startGameGetPlayerAndWaitForStartOfTurn(game);
+    setHand(player, ['Copper', 'Copper', 'Copper', 'Copper', 'Minion']);
+    const otherPlayer = game.playerOrder.find(p => p !== player);
+    await waitForNextInput();
+    respondWithCard('Minion');
+    await waitForNextInput();
+    respondWithChoice(0);
+    await waitForNextInput();
+    expect(player.hand.length).toBe(4);
+    expect(otherPlayer.hand.length).toBe(5);
+    expect(player.actions).toBe(1);
+    expect(player.money).toBe(2);
+  });
+
+  test('should attack', async () => {
+    const player = await startGameGetPlayerAndWaitForStartOfTurn(game);
+    setHand(player, ['Copper', 'Copper', 'Copper', 'Copper', 'Minion']);
+    setDeck(player, ['Copper', 'Silver', 'Silver', 'Silver', 'Silver']);
+    const otherPlayer = game.playerOrder.find(p => p !== player);
+    await waitForNextInput();
+    respondWithCard('Minion');
+    await waitForNextInput();
+    respondWithChoice(1);
+    await waitForNextInput();
+    expect(player.hand.length).toBe(4);
+    expect(player.hand.filter(c => c.title === 'Silver').length).toBe(4);
+    expect(otherPlayer.hand.length).toBe(4);
+    expect(player.actions).toBe(1);
+    expect(player.money).toBe(0);
+  });
+
+  test('should be blocked by Moat', async () => {
+    const player = await startGameGetPlayerAndWaitForStartOfTurn(game);
+    setHand(player, ['Copper', 'Copper', 'Copper', 'Copper', 'Minion']);
+    setDeck(player, ['Copper', 'Silver', 'Silver', 'Silver', 'Silver']);
+    const otherPlayer = game.playerOrder.find(p => p !== player);
+    setHand(otherPlayer, ['Copper', 'Copper', 'Copper', 'Copper', 'Moat']);
+    await waitForNextInput();
+    respondWithCard('Minion');
+
+    let { player: inputPlayer, lastInputWasValid } = await waitForNextInput();
+    expect(inputPlayer).toBe(otherPlayer);
+    expect(lastInputWasValid).toBe(true);
+    respondWithCard('Moat');
+
+    ({ player: inputPlayer, lastInputWasValid } = await waitForNextInput());
+    expect(lastInputWasValid).toBe(true);
+
+    expect(otherPlayer.hand.length).toBe(5);
+
+    respondWithChoice(1);
+    await waitForNextInput();
+    expect(player.hand.length).toBe(4);
+    expect(player.hand.filter(c => c.title === 'Silver').length).toBe(4);
+    expect(otherPlayer.hand.length).toBe(5);
+    expect(player.actions).toBe(1);
+    expect(player.money).toBe(0);
+  });
+};

--- a/src/tests/server/cards/intrigue/Nobles.js
+++ b/src/tests/server/cards/intrigue/Nobles.js
@@ -1,0 +1,44 @@
+import { test, beforeEach, expect } from '../../testingFramework';
+import { createGame, setHand, setDeck, respondWithCard, respondWithChoice, startGameGetPlayerAndWaitForStartOfTurn, waitForNextInput } from '../../toolbox';
+
+export default () => {
+  let game;
+
+  beforeEach(async () => {
+    game = await createGame();
+    game.getKingdomCards = () => ['Nobles'];
+  });
+
+  test('should draw', async () => {
+    const player = await startGameGetPlayerAndWaitForStartOfTurn(game);
+    setHand(player, ['Copper', 'Copper', 'Copper', 'Copper', 'Nobles']);
+    await waitForNextInput();
+    respondWithCard('Nobles');
+    await waitForNextInput();
+    respondWithChoice(0);
+    await waitForNextInput();
+    expect(player.hand.length).toBe(7);
+    expect(player.actions).toBe(0);
+  });
+
+  test('should give actions', async () => {
+    const player = await startGameGetPlayerAndWaitForStartOfTurn(game);
+    setHand(player, ['Copper', 'Copper', 'Copper', 'Copper', 'Nobles']);
+    await waitForNextInput();
+    respondWithCard('Nobles');
+    await waitForNextInput();
+    respondWithChoice(1);
+    await waitForNextInput();
+    expect(player.hand.length).toBe(4);
+    expect(player.actions).toBe(2);
+  });
+
+  test('Nobles should be worth 2', async () => {
+    const player = await startGameGetPlayerAndWaitForStartOfTurn(game);
+    setHand(player, ['Copper', 'Copper', 'Copper', 'Copper', 'Nobles']);
+    setDeck(player, ['Copper', 'Copper', 'Copper', 'Copper', 'Copper']);
+    await waitForNextInput();
+    game.endOfGame();
+    expect(player.score).toBe(2);
+  });
+};

--- a/src/tests/server/cards/intrigue/Patrol.js
+++ b/src/tests/server/cards/intrigue/Patrol.js
@@ -1,0 +1,34 @@
+import { test, beforeEach, expect } from '../../testingFramework';
+import { createGame, setHand, setDeck, respondWithCard, startGameGetPlayerAndWaitForStartOfTurn, waitForNextInput } from '../../toolbox';
+
+export default () => {
+  let game;
+
+  beforeEach(async () => {
+    game = await createGame();
+    game.getKingdomCards = () => ['Patrol'];
+  });
+
+  test('should draw 3', async () => {
+    const player = await startGameGetPlayerAndWaitForStartOfTurn(game);
+    setHand(player, ['Copper', 'Copper', 'Copper', 'Copper', 'Patrol']);
+    setDeck(player, ['Copper', 'Copper', 'Copper']);
+    await waitForNextInput();
+    respondWithCard('Patrol');
+    await waitForNextInput();
+    expect(player.hand.length).toBe(7);
+  });
+
+  test('should draw victory and curses from top 4', async () => {
+    const player = await startGameGetPlayerAndWaitForStartOfTurn(game);
+    setHand(player, ['Copper', 'Copper', 'Copper', 'Copper', 'Patrol']);
+    setDeck(player, ['Province', 'Curse', 'Estate', 'Silver', 'Copper', 'Copper', 'Copper']);
+    await waitForNextInput();
+    respondWithCard('Patrol');
+    await waitForNextInput();
+    expect(player.hand.length).toBe(10);
+    expect(player.hand.some(c => c.title === 'Estate')).toBe(true);
+    expect(player.hand.some(c => c.title === 'Province')).toBe(true);
+    expect(player.hand.some(c => c.title === 'Curse')).toBe(true);
+  });
+};

--- a/src/tests/server/cards/intrigue/Pawn.js
+++ b/src/tests/server/cards/intrigue/Pawn.js
@@ -1,0 +1,43 @@
+import { test, beforeEach, expect } from '../../testingFramework';
+import { createGame, setHand, respondWithCard, respondWithChoice, startGameGetPlayerAndWaitForStartOfTurn, waitForNextInput } from '../../toolbox';
+
+export default () => {
+  let game;
+
+  beforeEach(async () => {
+    game = await createGame();
+    game.getKingdomCards = () => ['Pawn'];
+  });
+
+  test('should act as a cantrip', async () => {
+    const player = await startGameGetPlayerAndWaitForStartOfTurn(game);
+    setHand(player, ['Copper', 'Copper', 'Copper', 'Copper', 'Pawn']);
+    await waitForNextInput();
+    respondWithCard('Pawn');
+    await waitForNextInput();
+    respondWithChoice(0);
+    await waitForNextInput();
+    respondWithChoice(0);
+    await waitForNextInput();
+    expect(player.hand.length).toBe(5);
+    expect(player.actions).toBe(1);
+    expect(player.buys).toBe(1);
+    expect(player.money).toBe(0);
+  });
+
+  test('should act as a cantrip', async () => {
+    const player = await startGameGetPlayerAndWaitForStartOfTurn(game);
+    setHand(player, ['Copper', 'Copper', 'Copper', 'Copper', 'Pawn']);
+    await waitForNextInput();
+    respondWithCard('Pawn');
+    await waitForNextInput();
+    respondWithChoice(2);
+    await waitForNextInput();
+    respondWithChoice(2);
+    await waitForNextInput();
+    expect(player.hand.length).toBe(4);
+    expect(player.actions).toBe(0);
+    expect(player.buys).toBe(2);
+    expect(player.money).toBe(1);
+  });
+};

--- a/src/tests/server/cards/intrigue/Replace.js
+++ b/src/tests/server/cards/intrigue/Replace.js
@@ -1,0 +1,113 @@
+import { test, beforeEach, expect } from '../../testingFramework';
+import { createGame, setHand, respondWithCard, respondWithSupply, startGameGetPlayerAndWaitForStartOfTurn, waitForNextInput } from '../../toolbox';
+
+export default () => {
+  let game;
+
+  beforeEach(async () => {
+    game = await createGame();
+    game.getKingdomCards = () => ['Replace', 'Island'];
+  });
+
+  test('Actions go onto deck', async () => {
+    const player = await startGameGetPlayerAndWaitForStartOfTurn(game);
+    setHand(player, ['Copper', 'Copper', 'Copper', 'Silver', 'Replace']);
+    await waitForNextInput();
+    respondWithCard('Replace');
+    await waitForNextInput();
+    respondWithCard('Silver');
+    await waitForNextInput();
+    respondWithSupply('Replace');
+    await waitForNextInput();
+    expect(player.hand.length).toBe(3);
+    expect(player.deck.last().title).toBe('Replace');
+  });
+
+  test('Treasures go onto deck', async () => {
+    const player = await startGameGetPlayerAndWaitForStartOfTurn(game);
+    setHand(player, ['Copper', 'Copper', 'Copper', 'Estate', 'Replace']);
+    await waitForNextInput();
+    respondWithCard('Replace');
+    await waitForNextInput();
+    respondWithCard('Estate');
+    await waitForNextInput();
+    respondWithSupply('Silver');
+    await waitForNextInput();
+    expect(player.hand.length).toBe(3);
+    expect(player.deck.last().title).toBe('Silver');
+  });
+
+  test('Victory cards attack', async () => {
+    const player = await startGameGetPlayerAndWaitForStartOfTurn(game);
+    setHand(player, ['Copper', 'Copper', 'Copper', 'Silver', 'Replace']);
+    const otherPlayer = game.playerOrder.find(p => p !== player);
+    await waitForNextInput();
+    respondWithCard('Replace');
+    await waitForNextInput();
+    respondWithCard('Silver');
+    await waitForNextInput();
+    respondWithSupply('Duchy');
+    await waitForNextInput();
+    expect(player.hand.length).toBe(3);
+    expect(player.deck.last().title).toNotBe('Silver');
+    expect(player.discardPile.last().title).toBe('Duchy');
+    expect(otherPlayer.discardPile.last().title).toBe('Curse');
+  });
+
+  test('Other cards do nothing', async () => {
+    const player = await startGameGetPlayerAndWaitForStartOfTurn(game);
+    setHand(player, ['Copper', 'Copper', 'Copper', 'Silver', 'Replace']);
+    const otherPlayer = game.playerOrder.find(p => p !== player);
+    await waitForNextInput();
+    respondWithCard('Replace');
+    await waitForNextInput();
+    respondWithCard('Silver');
+    await waitForNextInput();
+    respondWithSupply('Curse');
+    await waitForNextInput();
+    expect(player.hand.length).toBe(3);
+    expect(player.deck.last().title).toNotBe('Curse');
+    expect(player.discardPile.last().title).toBe('Curse');
+    expect(otherPlayer.discardPile.length).toBe(0);
+  });
+
+  test('Island should do both', async () => {
+    const player = await startGameGetPlayerAndWaitForStartOfTurn(game);
+    setHand(player, ['Copper', 'Copper', 'Copper', 'Estate', 'Replace']);
+    const otherPlayer = game.playerOrder.find(p => p !== player);
+    await waitForNextInput();
+    respondWithCard('Replace');
+    await waitForNextInput();
+    respondWithCard('Estate');
+    await waitForNextInput();
+    respondWithSupply('Island');
+    await waitForNextInput();
+    expect(player.hand.length).toBe(3);
+    expect(player.deck.last().title).toBe('Island');
+    expect(otherPlayer.discardPile.last().title).toBe('Curse');
+  });
+
+  test('should be blocked by Moat', async () => {
+    const player = await startGameGetPlayerAndWaitForStartOfTurn(game);
+    setHand(player, ['Copper', 'Copper', 'Copper', 'Copper', 'Replace']);
+    const otherPlayer = game.playerOrder.find(p => p !== player);
+    setHand(otherPlayer, ['Copper', 'Copper', 'Copper', 'Copper', 'Moat']);
+    await waitForNextInput();
+    respondWithCard('Replace');
+
+    let { player: inputPlayer, lastInputWasValid } = await waitForNextInput();
+    expect(inputPlayer).toBe(otherPlayer);
+    expect(lastInputWasValid).toBe(true);
+    respondWithCard('Moat');
+
+    ({ player: inputPlayer, lastInputWasValid } = await waitForNextInput());
+    expect(lastInputWasValid).toBe(true);
+
+    respondWithCard('Copper');
+    await waitForNextInput();
+    respondWithSupply('Estate');
+    await waitForNextInput();
+
+    expect(otherPlayer.discardPile.length).toBe(0);
+  });
+};

--- a/src/tests/server/cards/intrigue/Saboteur.js
+++ b/src/tests/server/cards/intrigue/Saboteur.js
@@ -1,0 +1,49 @@
+import { test, beforeEach, expect } from '../../testingFramework';
+import { createGame, setHand, setDeck, respondWithCard, respondWithSupply, startGameGetPlayerAndWaitForStartOfTurn, waitForNextInput } from '../../toolbox';
+
+export default () => {
+  let game;
+
+  beforeEach(async () => {
+    game = await createGame();
+    game.getKingdomCards = () => ['Saboteur'];
+  });
+
+  test('should attack', async () => {
+    const player = await startGameGetPlayerAndWaitForStartOfTurn(game);
+    setHand(player, ['Copper', 'Copper', 'Copper', 'Copper', 'Saboteur']);
+    const otherPlayer = game.playerOrder.find(p => p !== player);
+    setDeck(otherPlayer, ['Copper', 'Silver', 'Copper', 'Province', 'Copper']);
+    await waitForNextInput();
+    respondWithCard('Saboteur');
+    await waitForNextInput();
+    expect(otherPlayer.deck.length).toBe(1);
+    respondWithSupply('Curse');
+    await waitForNextInput();
+    expect(otherPlayer.discardPile.length).toBe(4);
+    expect(otherPlayer.discardPile.first().title).toBe('Curse');
+    expect(game.trash.last().title).toBe('Silver');
+  });
+
+  test('Potion cards do not cost between $3-$6');
+
+  test('should be blocked by Moat', async () => {
+    const player = await startGameGetPlayerAndWaitForStartOfTurn(game);
+    setHand(player, ['Copper', 'Copper', 'Copper', 'Copper', 'Saboteur']);
+    const otherPlayer = game.playerOrder.find(p => p !== player);
+    setHand(otherPlayer, ['Copper', 'Copper', 'Copper', 'Copper', 'Moat']);
+    setDeck(otherPlayer, ['Copper', 'Silver', 'Copper', 'Copper', 'Copper']);
+    await waitForNextInput();
+    respondWithCard('Saboteur');
+
+    let { player: inputPlayer, lastInputWasValid } = await waitForNextInput();
+    expect(inputPlayer).toBe(otherPlayer);
+    expect(lastInputWasValid).toBe(true);
+    respondWithCard('Moat');
+
+    ({ player: inputPlayer, lastInputWasValid } = await waitForNextInput());
+    expect(lastInputWasValid).toBe(true);
+
+    expect(otherPlayer.discardPile.length).toBe(0);
+  });
+};

--- a/src/tests/server/cards/intrigue/Scout.js
+++ b/src/tests/server/cards/intrigue/Scout.js
@@ -1,0 +1,28 @@
+import { test, beforeEach, expect } from '../../testingFramework';
+import { createGame, setHand, setDeck, respondWithCard, startGameGetPlayerAndWaitForStartOfTurn, waitForNextInput } from '../../toolbox';
+
+export default () => {
+  let game;
+
+  beforeEach(async () => {
+    game = await createGame();
+    game.getKingdomCards = () => ['Scout'];
+  });
+
+  test('should draw and return others', async () => {
+    const player = await startGameGetPlayerAndWaitForStartOfTurn(game);
+    setHand(player, ['Copper', 'Copper', 'Copper', 'Copper', 'Scout']);
+    setDeck(player, ['Copper', 'Province', 'Silver', 'Gold', 'GreatHall']);
+    await waitForNextInput();
+    respondWithCard('Scout');
+    await waitForNextInput();
+    expect(player.hand.length).toBe(6);
+    expect(player.actions).toBe(1);
+    respondWithCard('Silver');
+    await waitForNextInput();
+    expect(player.deck.last().title).toBe('Silver');
+    respondWithCard('Gold');
+    await waitForNextInput();
+    expect(player.deck.last().title).toBe('Gold');
+  });
+};

--- a/src/tests/server/cards/intrigue/SecretChamber.js
+++ b/src/tests/server/cards/intrigue/SecretChamber.js
@@ -1,0 +1,44 @@
+import { test, beforeEach, expect } from '../../testingFramework';
+import { createGame, setHand, respondWithCard, respondWithCards, startGameGetPlayerAndWaitForStartOfTurn, waitForNextInput } from '../../toolbox';
+
+export default () => {
+  let game;
+
+  beforeEach(async () => {
+    game = await createGame();
+    game.getKingdomCards = () => ['SecretChamber'];
+  });
+
+  test('should give money for discard', async () => {
+    const player = await startGameGetPlayerAndWaitForStartOfTurn(game);
+    setHand(player, ['Copper', 'Copper', 'Copper', 'Copper', 'SecretChamber']);
+    await waitForNextInput();
+    respondWithCard('SecretChamber');
+    await waitForNextInput();
+    respondWithCards(['Copper', 'Copper', 'Copper']);
+    await waitForNextInput();
+    expect(player.hand.length).toBe(1);
+    expect(player.money).toBe(3);
+  });
+
+  test('should react', async () => {
+    const player = await startGameGetPlayerAndWaitForStartOfTurn(game);
+    setHand(player, ['Copper', 'Copper', 'Copper', 'Copper', 'Militia']);
+    const otherPlayer = game.playerOrder.find(p => p !== player);
+    setHand(otherPlayer, ['Copper', 'Silver', 'Copper', 'Copper', 'SecretChamber']);
+    await waitForNextInput();
+    respondWithCard('Militia');
+    await waitForNextInput();
+    respondWithCard('SecretChamber');
+    await waitForNextInput();
+    expect(otherPlayer.hand.length).toBe(7);
+    respondWithCard('Copper');
+    await waitForNextInput();
+    expect(otherPlayer.hand.length).toBe(6);
+    expect(otherPlayer.deck.last().title).toBe('Copper');
+    respondWithCard('Silver');
+    await waitForNextInput();
+    expect(otherPlayer.hand.length).toBe(5);
+    expect(otherPlayer.deck.last().title).toBe('Silver');
+  });
+};

--- a/src/tests/server/cards/intrigue/SecretPassage.js
+++ b/src/tests/server/cards/intrigue/SecretPassage.js
@@ -1,0 +1,44 @@
+import { test, beforeEach, expect } from '../../testingFramework';
+import { createGame, setHand, setDeck, respondWithCard, respondWithChoice, startGameGetPlayerAndWaitForStartOfTurn, waitForNextInput } from '../../toolbox';
+
+export default () => {
+  let game;
+
+  beforeEach(async () => {
+    game = await createGame();
+    game.getKingdomCards = () => ['SecretPassage'];
+  });
+
+  test('should place card on top of deck', async () => {
+    const player = await startGameGetPlayerAndWaitForStartOfTurn(game);
+    setHand(player, ['Copper', 'Silver', 'Copper', 'Copper', 'SecretPassage']);
+    await waitForNextInput();
+    respondWithCard('SecretPassage');
+    await waitForNextInput();
+    expect(player.hand.length).toBe(6);
+    expect(player.actions).toBe(1);
+    respondWithCard('Silver');
+    await waitForNextInput();
+    respondWithChoice(0);
+    await waitForNextInput();
+    expect(player.hand.length).toBe(5);
+    expect(player.deck.last().title).toBe('Silver');
+  });
+
+  test('should place card where you want', async () => {
+    const player = await startGameGetPlayerAndWaitForStartOfTurn(game);
+    setHand(player, ['Copper', 'Silver', 'Copper', 'Copper', 'SecretPassage']);
+    setDeck(player, ['Gold', 'Silver', 'Copper', 'Copper', 'Copper']);
+    await waitForNextInput();
+    respondWithCard('SecretPassage');
+    await waitForNextInput();
+    expect(player.hand.length).toBe(6);
+    expect(player.actions).toBe(1);
+    respondWithCard('Silver');
+    await waitForNextInput();
+    respondWithCard('Gold');
+    await waitForNextInput();
+    expect(player.hand.length).toBe(5);
+    expect(player.deck.first().title).toBe('Silver');
+  });
+};

--- a/src/tests/server/cards/intrigue/ShantyTown.js
+++ b/src/tests/server/cards/intrigue/ShantyTown.js
@@ -1,0 +1,31 @@
+import { test, beforeEach, expect } from '../../testingFramework';
+import { createGame, setHand, respondWithCard, startGameGetPlayerAndWaitForStartOfTurn, waitForNextInput } from '../../toolbox';
+
+export default () => {
+  let game;
+
+  beforeEach(async () => {
+    game = await createGame();
+    game.getKingdomCards = () => ['ShantyTown'];
+  });
+
+  test('should draw with no actions', async () => {
+    const player = await startGameGetPlayerAndWaitForStartOfTurn(game);
+    setHand(player, ['Copper', 'Copper', 'Copper', 'Copper', 'ShantyTown']);
+    await waitForNextInput();
+    respondWithCard('ShantyTown');
+    await waitForNextInput();
+    expect(player.hand.length).toBe(6);
+    expect(player.actions).toBe(2);
+  });
+
+  test('shouldn\'t draw with an action card in hand', async () => {
+    const player = await startGameGetPlayerAndWaitForStartOfTurn(game);
+    setHand(player, ['Copper', 'Copper', 'Copper', 'Village', 'ShantyTown']);
+    await waitForNextInput();
+    respondWithCard('ShantyTown');
+    await waitForNextInput();
+    expect(player.hand.length).toBe(4);
+    expect(player.actions).toBe(2);
+  });
+};

--- a/src/tests/server/cards/intrigue/Steward.js
+++ b/src/tests/server/cards/intrigue/Steward.js
@@ -1,0 +1,50 @@
+import { test, beforeEach, expect } from '../../testingFramework';
+import { createGame, setHand, respondWithCard, respondWithChoice, respondWithCards, startGameGetPlayerAndWaitForStartOfTurn, waitForNextInput } from '../../toolbox';
+
+export default () => {
+  let game;
+
+  beforeEach(async () => {
+    game = await createGame();
+    game.getKingdomCards = () => ['Steward'];
+  });
+
+  test('should allow for draw', async () => {
+    const player = await startGameGetPlayerAndWaitForStartOfTurn(game);
+    setHand(player, ['Copper', 'Copper', 'Copper', 'Copper', 'Steward']);
+    await waitForNextInput();
+    respondWithCard('Steward');
+    await waitForNextInput();
+    respondWithChoice(0);
+    await waitForNextInput();
+    expect(player.hand.length).toBe(6);
+    expect(player.money).toBe(0);
+  });
+
+  test('should allow for money', async () => {
+    const player = await startGameGetPlayerAndWaitForStartOfTurn(game);
+    setHand(player, ['Copper', 'Copper', 'Copper', 'Copper', 'Steward']);
+    await waitForNextInput();
+    respondWithCard('Steward');
+    await waitForNextInput();
+    respondWithChoice(1);
+    await waitForNextInput();
+    expect(player.hand.length).toBe(4);
+    expect(player.money).toBe(2);
+  });
+
+  test('should allow for trash', async () => {
+    const player = await startGameGetPlayerAndWaitForStartOfTurn(game);
+    setHand(player, ['Copper', 'Copper', 'Copper', 'Copper', 'Steward']);
+    await waitForNextInput();
+    respondWithCard('Steward');
+    await waitForNextInput();
+    respondWithChoice(2);
+    await waitForNextInput();
+    respondWithCards(['Copper', 'Copper']);
+    await waitForNextInput();
+    expect(player.hand.length).toBe(2);
+    expect(player.money).toBe(0);
+    expect(game.trash.length).toBe(2);
+  });
+};

--- a/src/tests/server/cards/intrigue/Swindler.js
+++ b/src/tests/server/cards/intrigue/Swindler.js
@@ -1,0 +1,53 @@
+import { test, beforeEach, expect } from '../../testingFramework';
+import { createGame, setHand, setDeck, respondWithCard, respondWithSupply, startGameGetPlayerAndWaitForStartOfTurn, waitForNextInput } from '../../toolbox';
+
+export default () => {
+  let game;
+
+  beforeEach(async () => {
+    game = await createGame();
+    game.getKingdomCards = () => ['Swindler', 'Village'];
+  });
+
+  test('should attack', async () => {
+    const player = await startGameGetPlayerAndWaitForStartOfTurn(game);
+    setHand(player, ['Copper', 'Copper', 'Copper', 'Copper', 'Swindler']);
+    const otherPlayer = game.playerOrder.find(p => p !== player);
+    setDeck(otherPlayer, ['Copper', 'Copper', 'Copper', 'Copper', 'Silver']);
+    await waitForNextInput();
+    respondWithCard('Swindler');
+    await waitForNextInput();
+    respondWithSupply('Village');
+    await waitForNextInput();
+    expect(player.money).toBe(2);
+    expect(otherPlayer.deck.length).toBe(4);
+    expect(otherPlayer.discardPile.last().title).toBe('Village');
+    expect(game.trash.length).toBe(1);
+  });
+
+  test('works on potion cost cards');
+
+  test('works on debt cost cards');
+
+  test('should be blocked by Moat', async () => {
+    const player = await startGameGetPlayerAndWaitForStartOfTurn(game);
+    setHand(player, ['Copper', 'Copper', 'Copper', 'Copper', 'Swindler']);
+    const otherPlayer = game.playerOrder.find(p => p !== player);
+    setHand(otherPlayer, ['Copper', 'Copper', 'Copper', 'Copper', 'Moat']);
+    await waitForNextInput();
+    respondWithCard('Swindler');
+
+    let { player: inputPlayer, lastInputWasValid } = await waitForNextInput();
+    expect(inputPlayer).toBe(otherPlayer);
+    expect(lastInputWasValid).toBe(true);
+    respondWithCard('Moat');
+
+    ({ player: inputPlayer, lastInputWasValid } = await waitForNextInput());
+    expect(lastInputWasValid).toBe(true);
+
+    expect(otherPlayer.deck.length).toBe(5);
+    respondWithCard('Copper');
+    await waitForNextInput();
+    expect(player.money).toBe(3);
+  });
+};

--- a/src/tests/server/cards/intrigue/Torturer.js
+++ b/src/tests/server/cards/intrigue/Torturer.js
@@ -1,0 +1,73 @@
+import { test, beforeEach, expect } from '../../testingFramework';
+import { createGame, setHand, respondWithCard, respondWithCards, respondWithChoice, startGameGetPlayerAndWaitForStartOfTurn, waitForNextInput } from '../../toolbox';
+
+export default () => {
+  let game;
+
+  beforeEach(async () => {
+    game = await createGame();
+    game.getKingdomCards = () => ['Torturer'];
+  });
+
+  test('should draw 3', async () => {
+    const player = await startGameGetPlayerAndWaitForStartOfTurn(game);
+    setHand(player, ['Copper', 'Copper', 'Copper', 'Copper', 'Torturer']);
+    await waitForNextInput();
+    respondWithCard('Torturer');
+    await waitForNextInput();
+    expect(player.hand.length).toBe(7);
+  });
+
+  test('should discard attack', async () => {
+    const player = await startGameGetPlayerAndWaitForStartOfTurn(game);
+    setHand(player, ['Copper', 'Copper', 'Copper', 'Copper', 'Torturer']);
+    const otherPlayer = game.playerOrder.find(p => p !== player);
+    setHand(otherPlayer, ['Copper', 'Copper', 'Copper', 'Copper', 'Copper']);
+    await waitForNextInput();
+    respondWithCard('Torturer');
+    await waitForNextInput();
+    respondWithChoice(0);
+    await waitForNextInput();
+    respondWithCards(['Copper', 'Copper']);
+    await waitForNextInput();
+    expect(player.hand.length).toBe(7);
+    expect(otherPlayer.hand.length).toBe(3);
+  });
+
+  test('should curse attack', async () => {
+    const player = await startGameGetPlayerAndWaitForStartOfTurn(game);
+    setHand(player, ['Copper', 'Copper', 'Copper', 'Copper', 'Torturer']);
+    const otherPlayer = game.playerOrder.find(p => p !== player);
+    setHand(otherPlayer, ['Copper', 'Copper', 'Copper', 'Copper', 'Copper']);
+    await waitForNextInput();
+    respondWithCard('Torturer');
+    await waitForNextInput();
+    respondWithChoice(1);
+    await waitForNextInput();
+    expect(player.hand.length).toBe(7);
+    expect(otherPlayer.hand.length).toBe(6);
+    expect(otherPlayer.hand.some(c => c.title === 'Curse')).toBe(true);
+  });
+
+  test('should be blocked by Moat', async () => {
+    const player = await startGameGetPlayerAndWaitForStartOfTurn(game);
+    setHand(player, ['Copper', 'Copper', 'Copper', 'Copper', 'Torturer']);
+    const otherPlayer = game.playerOrder.find(p => p !== player);
+    setHand(otherPlayer, ['Copper', 'Copper', 'Copper', 'Copper', 'Moat']);
+    await waitForNextInput();
+    respondWithCard('Torturer');
+
+    let { player: inputPlayer, lastInputWasValid } = await waitForNextInput();
+    expect(inputPlayer).toBe(otherPlayer);
+    expect(lastInputWasValid).toBe(true);
+    respondWithCard('Moat');
+
+    ({ player: inputPlayer, lastInputWasValid } = await waitForNextInput());
+    expect(lastInputWasValid).toBe(true);
+
+    expect(otherPlayer.hand.length).toBe(5);
+    respondWithCard('Copper');
+    await waitForNextInput();
+    expect(player.money).toBe(1);
+  });
+};

--- a/src/tests/server/cards/intrigue/TradingPost.js
+++ b/src/tests/server/cards/intrigue/TradingPost.js
@@ -1,0 +1,35 @@
+import { test, beforeEach, expect } from '../../testingFramework';
+import { createGame, setHand, respondWithCard, respondWithCards, startGameGetPlayerAndWaitForStartOfTurn, waitForNextInput } from '../../toolbox';
+
+export default () => {
+  let game;
+
+  beforeEach(async () => {
+    game = await createGame();
+    game.getKingdomCards = () => ['TradingPost'];
+  });
+
+  test('should trash for silver', async () => {
+    const player = await startGameGetPlayerAndWaitForStartOfTurn(game);
+    setHand(player, ['Copper', 'Copper', 'Copper', 'Copper', 'TradingPost']);
+    await waitForNextInput();
+    respondWithCard('TradingPost');
+    await waitForNextInput();
+    respondWithCards(['Copper', 'Copper']);
+    await waitForNextInput();
+    expect(player.hand.length).toBe(3);
+    expect(player.hand.some(c => c.title === 'Silver')).toBe(true);
+  });
+
+  test('should not gain if didn\'t trash enough', async () => {
+    const player = await startGameGetPlayerAndWaitForStartOfTurn(game);
+    setHand(player, ['Copper','TradingPost']);
+    await waitForNextInput();
+    respondWithCard('TradingPost');
+    await waitForNextInput();
+    respondWithCards(['Copper']);
+    await waitForNextInput();
+    expect(player.hand.length).toBe(0);
+    expect(player.hand.some(c => c.title === 'Silver')).toBe(false);
+  });
+};

--- a/src/tests/server/cards/intrigue/Tribute.js
+++ b/src/tests/server/cards/intrigue/Tribute.js
@@ -1,0 +1,67 @@
+import { test, beforeEach, expect } from '../../testingFramework';
+import { createGame, setHand, setDeck, respondWithCard, startGameGetPlayerAndWaitForStartOfTurn, waitForNextInput } from '../../toolbox';
+
+export default () => {
+  let game;
+
+  beforeEach(async () => {
+    game = await createGame();
+    game.getKingdomCards = () => ['Tribute'];
+  });
+
+  test('shouldn\'t count duplicates', async () => {
+    const player = await startGameGetPlayerAndWaitForStartOfTurn(game);
+    setHand(player, ['Copper', 'Copper', 'Copper', 'Copper', 'Tribute']);
+    const otherPlayer = game.playerOrder.find(p => p !== player);
+    setDeck(otherPlayer, ['Copper', 'Copper', 'Copper', 'Copper', 'Copper']);
+    await waitForNextInput();
+    respondWithCard('Tribute');
+    await waitForNextInput();
+    expect(player.hand.length).toBe(4);
+    expect(player.actions).toBe(0);
+    expect(player.buys).toBe(1);
+    expect(player.money).toBe(2);
+  });
+
+  test('should give money', async () => {
+    const player = await startGameGetPlayerAndWaitForStartOfTurn(game);
+    setHand(player, ['Copper', 'Copper', 'Copper', 'Copper', 'Tribute']);
+    const otherPlayer = game.playerOrder.find(p => p !== player);
+    setDeck(otherPlayer, ['Copper', 'Copper', 'Copper', 'Silver', 'Copper']);
+    await waitForNextInput();
+    respondWithCard('Tribute');
+    await waitForNextInput();
+    expect(player.hand.length).toBe(4);
+    expect(player.actions).toBe(0);
+    expect(player.buys).toBe(1);
+    expect(player.money).toBe(4);
+  });
+
+  test('should consider multiple types', async () => {
+    const player = await startGameGetPlayerAndWaitForStartOfTurn(game);
+    setHand(player, ['Copper', 'Copper', 'Copper', 'Copper', 'Tribute']);
+    const otherPlayer = game.playerOrder.find(p => p !== player);
+    setDeck(otherPlayer, ['Copper', 'Copper', 'Copper', 'Mill', 'Harem']);
+    await waitForNextInput();
+    respondWithCard('Tribute');
+    await waitForNextInput();
+    expect(player.hand.length).toBe(8);
+    expect(player.actions).toBe(2);
+    expect(player.buys).toBe(1);
+    expect(player.money).toBe(2);
+  });
+
+  test('should give actions', async () => {
+    const player = await startGameGetPlayerAndWaitForStartOfTurn(game);
+    setHand(player, ['Copper', 'Copper', 'Copper', 'Copper', 'Tribute']);
+    const otherPlayer = game.playerOrder.find(p => p !== player);
+    setDeck(otherPlayer, ['Copper', 'Copper', 'Copper', 'Tribute', 'Silver']);
+    await waitForNextInput();
+    respondWithCard('Tribute');
+    await waitForNextInput();
+    expect(player.hand.length).toBe(4);
+    expect(player.actions).toBe(2);
+    expect(player.buys).toBe(1);
+    expect(player.money).toBe(2);
+  });
+};

--- a/src/tests/server/cards/intrigue/Upgrade.js
+++ b/src/tests/server/cards/intrigue/Upgrade.js
@@ -1,0 +1,44 @@
+import { test, beforeEach, expect } from '../../testingFramework';
+import { createGame, setHand, respondWithCard, respondWithSupply, startGameGetPlayerAndWaitForStartOfTurn, waitForNextInput } from '../../toolbox';
+
+export default () => {
+  let game;
+
+  beforeEach(async () => {
+    game = await createGame();
+    game.getKingdomCards = () => ['Upgrade'];
+  });
+
+  test('should gain a card costing one more', async () => {
+    const player = await startGameGetPlayerAndWaitForStartOfTurn(game);
+    setHand(player, ['Copper', 'Copper', 'Copper', 'Estate', 'Upgrade']);
+    await waitForNextInput();
+    respondWithCard('Upgrade');
+    await waitForNextInput();
+    respondWithCard('Estate');
+    await waitForNextInput();
+    respondWithSupply('Silver');
+    await waitForNextInput();
+    expect(player.hand.length).toBe(4);
+    expect(player.actions).toBe(1);
+    expect(player.discardPile.last().title).toBe('Silver');
+  });
+
+  test('should be fine if no cards to gain', async () => {
+    const player = await startGameGetPlayerAndWaitForStartOfTurn(game);
+    setHand(player, ['Copper', 'Copper', 'Copper', 'Estate', 'Upgrade']);
+    await waitForNextInput();
+    respondWithCard('Upgrade');
+    await waitForNextInput();
+    respondWithCard('Copper');
+    await waitForNextInput();
+    respondWithCard('Copper');
+    await waitForNextInput();
+    expect(player.hand.length).toBe(3);
+    expect(player.actions).toBe(1);
+    expect(player.money).toBe(1);
+    expect(player.discardPile.length).toBe(0);
+  });
+
+  test('Should gain a card costing one more even if there is a potion in the cost');
+};

--- a/src/tests/server/cards/intrigue/WishingWell.js
+++ b/src/tests/server/cards/intrigue/WishingWell.js
@@ -1,0 +1,55 @@
+import { test, beforeEach, expect } from '../../testingFramework';
+import { createGame, setHand, setDeck, respondWithCard, respondWithSupply, startGameGetPlayerAndWaitForStartOfTurn, waitForNextInput } from '../../toolbox';
+
+export default () => {
+  let game;
+
+  beforeEach(async () => {
+    game = await createGame();
+    game.getKingdomCards = () => ['WishingWell'];
+  });
+
+  test('should not draw if named wrong', async () => {
+    const player = await startGameGetPlayerAndWaitForStartOfTurn(game);
+    setHand(player, ['Copper', 'Copper', 'Copper', 'Copper', 'WishingWell']);
+    setDeck(player, ['Copper', 'Copper', 'Copper', 'Gold', 'Silver']);
+    await waitForNextInput();
+    respondWithCard('WishingWell');
+    await waitForNextInput();
+    expect(player.hand.length).toBe(5);
+    expect(player.actions).toBe(1);
+    respondWithSupply('Silver');
+    await waitForNextInput();
+    expect(player.hand.length).toBe(5);
+    expect(player.deck.last().title).toBe('Gold');
+  });
+
+  test('should draw if named correctly', async () => {
+    const player = await startGameGetPlayerAndWaitForStartOfTurn(game);
+    setHand(player, ['Copper', 'Copper', 'Copper', 'Copper', 'WishingWell']);
+    setDeck(player, ['Copper', 'Copper', 'Estate', 'Gold', 'Silver']);
+    await waitForNextInput();
+    respondWithCard('WishingWell');
+    await waitForNextInput();
+    expect(player.hand.length).toBe(5);
+    expect(player.actions).toBe(1);
+    respondWithSupply('Gold');
+    await waitForNextInput();
+    expect(player.hand.length).toBe(6);
+    expect(player.deck.last().title).toBe('Estate');
+  });
+
+  test('should be fine with empty deck', async () => {
+    const player = await startGameGetPlayerAndWaitForStartOfTurn(game);
+    setHand(player, ['Copper', 'Copper', 'Copper', 'Copper', 'WishingWell']);
+    setDeck(player, []);
+    await waitForNextInput();
+    respondWithCard('WishingWell');
+    await waitForNextInput();
+    expect(player.hand.length).toBe(4);
+    expect(player.actions).toBe(1);
+    respondWithSupply('Gold');
+    await waitForNextInput();
+    expect(player.hand.length).toBe(4);
+  });
+};

--- a/src/tests/server/cards/seaside/Ambassador.js
+++ b/src/tests/server/cards/seaside/Ambassador.js
@@ -1,0 +1,68 @@
+import { test, beforeEach, expect } from '../../testingFramework';
+import { createGame, setHand, respondWithCard, respondWithCards, respondWithNoCards, startGameGetPlayerAndWaitForStartOfTurn, waitForNextInput } from '../../toolbox';
+
+export default () => {
+  let game;
+
+  beforeEach(async () => {
+    game = await createGame();
+    game.getKingdomCards = () => ['Ambassador'];
+  });
+
+  test('Can return cards', async () => {
+    const player = await startGameGetPlayerAndWaitForStartOfTurn(game);
+    setHand(player, ['Copper', 'Copper', 'Estate', 'Estate', 'Ambassador']);
+    const otherPlayer = game.playerOrder.find(p => p !== player);
+    setHand(otherPlayer, ['Copper', 'Copper', 'Copper', 'Copper', 'Copper']);
+    await waitForNextInput();
+    respondWithCard('Ambassador');
+    await waitForNextInput();
+    respondWithCard('Estate');
+    await waitForNextInput();
+    respondWithCards(['Estate', 'Estate']);
+    await waitForNextInput();
+    expect(player.hand.length).toBe(2);
+    expect(game.supplies.get('Estate').cards.length).toBe(9);
+  });
+
+  test('Can return none', async () => {
+    const player = await startGameGetPlayerAndWaitForStartOfTurn(game);
+    setHand(player, ['Copper', 'Copper', 'Estate', 'Estate', 'Ambassador']);
+    const otherPlayer = game.playerOrder.find(p => p !== player);
+    setHand(otherPlayer, ['Copper', 'Copper', 'Copper', 'Copper', 'Copper']);
+    await waitForNextInput();
+    respondWithCard('Ambassador');
+    await waitForNextInput();
+    respondWithCard('Estate');
+    await waitForNextInput();
+    respondWithNoCards();
+    await waitForNextInput();
+    expect(player.hand.length).toBe(4);
+    expect(game.supplies.get('Estate').cards.length).toBe(7);
+  });
+
+  test('Can return to Split piles');
+
+  test('should be blocked by Moat', async () => {
+    const player = await startGameGetPlayerAndWaitForStartOfTurn(game);
+    setHand(player, ['Copper', 'Copper', 'Estate', 'Estate', 'Ambassador']);
+    const otherPlayer = game.playerOrder.find(p => p !== player);
+    setHand(otherPlayer, ['Copper', 'Copper', 'Copper', 'Copper', 'Moat']);
+    await waitForNextInput();
+    respondWithCard('Ambassador');
+
+    let { player: inputPlayer, lastInputWasValid } = await waitForNextInput();
+    expect(inputPlayer).toBe(otherPlayer);
+    expect(lastInputWasValid).toBe(true);
+    respondWithCard('Moat');
+
+    ({ player: inputPlayer, lastInputWasValid } = await waitForNextInput());
+    expect(lastInputWasValid).toBe(true);
+
+    respondWithCard('Estate');
+    await waitForNextInput();
+    respondWithCards(['Estate', 'Estate']);
+    await waitForNextInput();
+    expect(game.supplies.get('Estate').cards.length).toBe(10);
+  });
+};

--- a/src/tests/server/cards/seaside/Bazaar.js
+++ b/src/tests/server/cards/seaside/Bazaar.js
@@ -1,0 +1,22 @@
+import { test, beforeEach, expect } from '../../testingFramework';
+import { createGame, setHand, respondWithCard, startGameGetPlayerAndWaitForStartOfTurn, waitForNextInput } from '../../toolbox';
+
+export default () => {
+  let game;
+
+  beforeEach(async () => {
+    game = await createGame();
+    game.getKingdomCards = () => ['Bazaar'];
+  });
+
+  test('should give stuff', async () => {
+    const player = await startGameGetPlayerAndWaitForStartOfTurn(game);
+    setHand(player, ['Copper', 'Copper', 'Copper', 'Copper', 'Bazaar']);
+    await waitForNextInput();
+    respondWithCard('Bazaar');
+    await waitForNextInput();
+    expect(player.hand.length).toBe(5);
+    expect(player.actions).toBe(2);
+    expect(player.money).toBe(1);
+  });
+};

--- a/src/tests/server/cards/seaside/Caravan.js
+++ b/src/tests/server/cards/seaside/Caravan.js
@@ -1,0 +1,25 @@
+import { test, beforeEach, expect } from '../../testingFramework';
+import { createGame, setHand, respondWithCard, skipToNextTurn, startGameGetPlayerAndWaitForStartOfTurn, waitForNextInput } from '../../toolbox';
+
+export default () => {
+  let game;
+
+  beforeEach(async () => {
+    game = await createGame();
+    game.getKingdomCards = () => ['Caravan'];
+  });
+
+  test('should give stuff now and next turn', async () => {
+    const player = await startGameGetPlayerAndWaitForStartOfTurn(game);
+    setHand(player, ['Copper', 'Copper', 'Copper', 'Copper', 'Caravan']);
+    await waitForNextInput();
+    respondWithCard('Caravan');
+    await waitForNextInput();
+    expect(player.actions).toBe(1);
+    expect(player.hand.length).toBe(5);
+    await skipToNextTurn(player);
+    await waitForNextInput();
+    expect(player.actions).toBe(1);
+    expect(player.hand.length).toBe(6);
+  });
+};

--- a/src/tests/server/cards/seaside/Cutpurse.js
+++ b/src/tests/server/cards/seaside/Cutpurse.js
@@ -1,0 +1,54 @@
+import { test, beforeEach, expect } from '../../testingFramework';
+import { createGame, setHand, respondWithCard, startGameGetPlayerAndWaitForStartOfTurn, waitForNextInput } from '../../toolbox';
+
+export default () => {
+  let game;
+
+  beforeEach(async () => {
+    game = await createGame();
+    game.getKingdomCards = () => ['Cutpurse'];
+  });
+
+  test('should discard copper', async () => {
+    const player = await startGameGetPlayerAndWaitForStartOfTurn(game);
+    setHand(player, ['Copper', 'Copper', 'Copper', 'Copper', 'Cutpurse']);
+    const otherPlayer = game.playerOrder.find(p => p !== player);
+    setHand(otherPlayer, ['Copper', 'Copper', 'Copper', 'Copper', 'Copper']);
+    await waitForNextInput();
+    respondWithCard('Cutpurse');
+    await waitForNextInput();
+    expect(otherPlayer.hand.length).toBe(4);
+    expect(player.money).toBe(2);
+  });
+
+  test('should discard nothing if no copper', async () => {
+    const player = await startGameGetPlayerAndWaitForStartOfTurn(game);
+    setHand(player, ['Copper', 'Copper', 'Copper', 'Copper', 'Cutpurse']);
+    const otherPlayer = game.playerOrder.find(p => p !== player);
+    setHand(otherPlayer, ['Estate', 'Estate', 'Estate', 'Estate', 'Estate']);
+    await waitForNextInput();
+    respondWithCard('Cutpurse');
+    await waitForNextInput();
+    expect(otherPlayer.hand.length).toBe(5);
+    expect(player.money).toBe(2);
+  });
+
+  test('should be blocked by Moat', async () => {
+    const player = await startGameGetPlayerAndWaitForStartOfTurn(game);
+    setHand(player, ['Copper', 'Copper', 'Copper', 'Copper', 'Cutpurse']);
+    const otherPlayer = game.playerOrder.find(p => p !== player);
+    setHand(otherPlayer, ['Copper', 'Copper', 'Copper', 'Copper', 'Moat']);
+    await waitForNextInput();
+    respondWithCard('Cutpurse');
+
+    let { player: inputPlayer, lastInputWasValid } = await waitForNextInput();
+    expect(inputPlayer).toBe(otherPlayer);
+    expect(lastInputWasValid).toBe(true);
+    respondWithCard('Moat');
+
+    ({ player: inputPlayer, lastInputWasValid } = await waitForNextInput());
+    expect(lastInputWasValid).toBe(true);
+
+    expect(otherPlayer.hand.length).toBe(5);
+  });
+};

--- a/src/tests/server/cards/seaside/Embargo.js
+++ b/src/tests/server/cards/seaside/Embargo.js
@@ -1,0 +1,72 @@
+import { test, beforeEach, expect } from '../../testingFramework';
+import { createGame, setHand, setDeck, respondWithCard, respondWithSupply, skipToNextTurn, startGameGetPlayerAndWaitForStartOfTurn, waitForNextInput } from '../../toolbox';
+
+export default () => {
+  let game;
+
+  beforeEach(async () => {
+    game = await createGame();
+    game.getKingdomCards = () => ['Embargo'];
+  });
+
+  test('should give money and trash self', async () => {
+    const player = await startGameGetPlayerAndWaitForStartOfTurn(game);
+    setHand(player, ['Copper', 'Copper', 'Copper', 'Copper', 'Embargo']);
+    await waitForNextInput();
+    respondWithCard('Embargo');
+    await waitForNextInput();
+    respondWithSupply('Embargo');
+    await waitForNextInput();
+    expect(game.trash.last().title).toBe('Embargo');
+    expect(player.money).toBe(2);
+  });
+
+  test('should curse', async () => {
+    const player = await startGameGetPlayerAndWaitForStartOfTurn(game);
+    setHand(player, ['Copper', 'Copper', 'Copper', 'Copper', 'Embargo']);
+    await waitForNextInput();
+    respondWithCard('Embargo');
+    await waitForNextInput();
+    respondWithSupply('Embargo');
+    await skipToNextTurn(player);
+
+    setHand(player, ['Silver']);
+    setDeck(player, ['Copper', 'Copper', 'Copper', 'Copper', 'Copper']);
+    await waitForNextInput();
+    respondWithCard('Silver');
+    await waitForNextInput();
+    respondWithSupply('Embargo');
+    await waitForNextInput();
+    expect(player.discardPile.some(c => c.title === 'Curse')).toBe(true);
+  });
+
+  test('should stack', async () => {
+    const player = await startGameGetPlayerAndWaitForStartOfTurn(game);
+    setHand(player, ['Village', 'Village', 'Embargo', 'Embargo', 'Embargo']);
+    await waitForNextInput();
+    respondWithCard('Village');
+    await waitForNextInput();
+    respondWithCard('Village');
+    await waitForNextInput();
+    respondWithCard('Embargo');
+    await waitForNextInput();
+    respondWithSupply('Embargo');
+    await waitForNextInput();
+    respondWithCard('Embargo');
+    await waitForNextInput();
+    respondWithSupply('Embargo');
+    await waitForNextInput();
+    respondWithCard('Embargo');
+    await waitForNextInput();
+    respondWithSupply('Embargo');
+    await skipToNextTurn(player);
+
+    setHand(player, ['Silver']);
+    await waitForNextInput();
+    respondWithCard('Silver');
+    await waitForNextInput();
+    respondWithSupply('Embargo');
+    await waitForNextInput();
+    expect(player.discardPile.filter(c => c.title === 'Curse').length).toBe(3);
+  });
+};

--- a/src/tests/server/cards/seaside/Explorer.js
+++ b/src/tests/server/cards/seaside/Explorer.js
@@ -1,0 +1,45 @@
+import { test, beforeEach, expect } from '../../testingFramework';
+import { createGame, setHand, respondWithCard, respondWithNoCards, startGameGetPlayerAndWaitForStartOfTurn, waitForNextInput } from '../../toolbox';
+
+export default () => {
+  let game;
+
+  beforeEach(async () => {
+    game = await createGame();
+    game.getKingdomCards = () => ['Explorer'];
+  });
+
+  test('should gain silver', async () => {
+    const player = await startGameGetPlayerAndWaitForStartOfTurn(game);
+    setHand(player, ['Copper', 'Copper', 'Copper', 'Copper', 'Explorer']);
+    await waitForNextInput();
+    respondWithCard('Explorer');
+    await waitForNextInput();
+    expect(player.hand.length).toBe(5);
+    expect(player.hand.filter(c => c.title === 'Silver').length).toBe(1);
+  });
+
+  test('should gain gold with a province', async () => {
+    const player = await startGameGetPlayerAndWaitForStartOfTurn(game);
+    setHand(player, ['Copper', 'Copper', 'Copper', 'Province', 'Explorer']);
+    await waitForNextInput();
+    respondWithCard('Explorer');
+    await waitForNextInput();
+    respondWithCard('Province');
+    await waitForNextInput();
+    expect(player.hand.length).toBe(5);
+    expect(player.hand.filter(c => c.title === 'Gold').length).toBe(1);
+  });
+
+  test('should allow not revaling province', async () => {
+    const player = await startGameGetPlayerAndWaitForStartOfTurn(game);
+    setHand(player, ['Copper', 'Copper', 'Copper', 'Province', 'Explorer']);
+    await waitForNextInput();
+    respondWithCard('Explorer');
+    await waitForNextInput();
+    respondWithNoCards();
+    await waitForNextInput();
+    expect(player.hand.length).toBe(5);
+    expect(player.hand.filter(c => c.title === 'Silver').length).toBe(1);
+  });
+};

--- a/src/tests/server/cards/seaside/FishingVillage.js
+++ b/src/tests/server/cards/seaside/FishingVillage.js
@@ -1,0 +1,26 @@
+import { test, beforeEach, expect } from '../../testingFramework';
+import { createGame, setHand, respondWithCard, skipToNextTurn, startGameGetPlayerAndWaitForStartOfTurn, waitForNextInput } from '../../toolbox';
+
+export default () => {
+  let game;
+
+  beforeEach(async () => {
+    game = await createGame();
+    game.getKingdomCards = () => ['FishingVillage'];
+  });
+
+  test('should give stuff now and next turn', async () => {
+    const player = await startGameGetPlayerAndWaitForStartOfTurn(game);
+    setHand(player, ['Copper', 'Copper', 'Copper', 'Copper', 'FishingVillage']);
+    await waitForNextInput();
+    respondWithCard('FishingVillage');
+    await waitForNextInput();
+    expect(player.actions).toBe(2);
+    expect(player.money).toBe(1);
+    
+    await skipToNextTurn(player);
+    await waitForNextInput();
+    expect(player.actions).toBe(2);
+    expect(player.money).toBe(1);
+  });
+};

--- a/src/tests/server/cards/seaside/GhostShip.js
+++ b/src/tests/server/cards/seaside/GhostShip.js
@@ -1,0 +1,64 @@
+import { test, beforeEach, expect } from '../../testingFramework';
+import { createGame, setHand, setDeck, respondWithCard, startGameGetPlayerAndWaitForStartOfTurn, waitForNextInput } from '../../toolbox';
+
+export default () => {
+  let game;
+
+  beforeEach(async () => {
+    game = await createGame();
+    game.getKingdomCards = () => ['GhostShip'];
+  });
+
+  test('should force top decking', async () => {
+    const player = await startGameGetPlayerAndWaitForStartOfTurn(game);
+    setHand(player, ['Copper', 'Copper', 'Copper', 'Copper', 'GhostShip']);
+    const otherPlayer = game.playerOrder.find(p => p !== player);
+    setHand(otherPlayer, ['Copper', 'Copper', 'Copper', 'Copper', 'Silver']);
+    setDeck(otherPlayer, ['Estate', 'Estate', 'Estate', 'Estate', 'Estate']);
+    await waitForNextInput();
+    respondWithCard('GhostShip');
+    await waitForNextInput();
+    respondWithCard('Copper');
+    await waitForNextInput();
+    respondWithCard('Silver');
+    await waitForNextInput();
+    expect(player.hand.length).toBe(6);
+    expect(otherPlayer.hand.length).toBe(3);
+    expect(otherPlayer.deck.last().title).toBe('Silver');
+  });
+
+  test('shouldn\'t force players with smaller hands', async () => {
+    const player = await startGameGetPlayerAndWaitForStartOfTurn(game);
+    setHand(player, ['Copper', 'Copper', 'Copper', 'Gold', 'GhostShip']);
+    const otherPlayer = game.playerOrder.find(p => p !== player);
+    setHand(otherPlayer, ['Copper', 'Copper', 'Silver']);
+    setDeck(otherPlayer, ['Estate', 'Estate', 'Estate', 'Estate', 'Estate']);
+    await waitForNextInput();
+    respondWithCard('GhostShip');
+    await waitForNextInput();
+    respondWithCard('Gold');
+    await waitForNextInput();
+    expect(player.hand.length).toBe(5);
+    expect(otherPlayer.hand.length).toBe(3);
+    expect(otherPlayer.deck.last().title).toBe('Estate');
+  });
+
+  test('should be blocked by Moat', async () => {
+    const player = await startGameGetPlayerAndWaitForStartOfTurn(game);
+    setHand(player, ['Copper', 'Copper', 'Copper', 'Copper', 'GhostShip']);
+    const otherPlayer = game.playerOrder.find(p => p !== player);
+    setHand(otherPlayer, ['Copper', 'Copper', 'Copper', 'Copper', 'Moat']);
+    await waitForNextInput();
+    respondWithCard('GhostShip');
+
+    let { player: inputPlayer, lastInputWasValid } = await waitForNextInput();
+    expect(inputPlayer).toBe(otherPlayer);
+    expect(lastInputWasValid).toBe(true);
+    respondWithCard('Moat');
+
+    ({ player: inputPlayer, lastInputWasValid } = await waitForNextInput());
+    expect(lastInputWasValid).toBe(true);
+
+    expect(otherPlayer.hand.length).toBe(5);
+  });
+};

--- a/src/tests/server/cards/seaside/Haven.js
+++ b/src/tests/server/cards/seaside/Haven.js
@@ -1,0 +1,51 @@
+import { test, beforeEach, expect } from '../../testingFramework';
+import { createGame, setHand, setDeck, respondWithCard, skipToNextTurn, startGameGetPlayerAndWaitForStartOfTurn, waitForNextInput } from '../../toolbox';
+
+export default () => {
+  let game;
+
+  beforeEach(async () => {
+    game = await createGame();
+    game.getKingdomCards = () => ['Haven'];
+  });
+
+  test('should save card for next turn', async () => {
+    const player = await startGameGetPlayerAndWaitForStartOfTurn(game);
+    setHand(player, ['Copper', 'Copper', 'Copper', 'Gold', 'Haven']);
+    await waitForNextInput();
+    respondWithCard('Haven');
+    await waitForNextInput();
+    respondWithCard('Gold');
+    await skipToNextTurn(player);
+    await waitForNextInput();
+
+    expect(player.hand.some(c => c.title === 'Gold')).toBe(true);
+  });
+
+  test('should be found at end of game', async () => {
+    const player = await startGameGetPlayerAndWaitForStartOfTurn(game);
+    setHand(player, ['Copper', 'Copper', 'Copper', 'Province', 'Haven']);
+    setDeck(player, ['Copper', 'Copper', 'Copper', 'Copper', 'Copper']);
+    await waitForNextInput();
+    respondWithCard('Haven');
+    await waitForNextInput();
+    respondWithCard('Province');
+    await waitForNextInput();
+    game.endOfGame();
+    expect(player.score).toBe(6);
+  });
+
+  test('shouldn\'t stay out if nothing placed on it', async () => {
+    const player = await startGameGetPlayerAndWaitForStartOfTurn(game);
+    setHand(player, ['Haven']);
+    setDeck(player, []);
+    await waitForNextInput();
+    respondWithCard('Haven');
+
+    await skipToNextTurn(player);
+    await waitForNextInput();
+    expect(player.playArea.length).toBe(0);
+  });
+
+  test('should work with Throne Room'); // puts two cards on top, both go to hand, both are found at end of game
+};

--- a/src/tests/server/cards/seaside/Island.js
+++ b/src/tests/server/cards/seaside/Island.js
@@ -1,0 +1,34 @@
+import { test, beforeEach, expect } from '../../testingFramework';
+import { createGame, setHand, setDeck, respondWithCard, startGameGetPlayerAndWaitForStartOfTurn, waitForNextInput } from '../../toolbox';
+
+export default () => {
+  let game;
+
+  beforeEach(async () => {
+    game = await createGame();
+    game.getKingdomCards = () => ['Island'];
+  });
+
+  test('Gardens should be worth 2', async () => {
+    const player = await startGameGetPlayerAndWaitForStartOfTurn(game);
+    setHand(player, ['Copper', 'Copper', 'Copper', 'Copper', 'Island']);
+    setDeck(player, ['Copper', 'Copper', 'Copper', 'Copper']);
+    await waitForNextInput();
+    game.endOfGame();
+    expect(player.score).toBe(2);
+  });
+
+  test('Can put on mat', async () => {
+    const player = await startGameGetPlayerAndWaitForStartOfTurn(game);
+    setHand(player, ['Copper', 'Copper', 'Copper', 'Estate', 'Island']);
+    setDeck(player, Array(5).fill('Copper'));
+    await waitForNextInput();
+    respondWithCard('Island');
+    await waitForNextInput();
+    respondWithCard('Estate');
+    await waitForNextInput();
+    expect(player.mats.island.length).toBe(2);
+    game.endOfGame();
+    expect(player.score).toBe(3);
+  });
+};

--- a/src/tests/server/cards/seaside/Lighthouse.js
+++ b/src/tests/server/cards/seaside/Lighthouse.js
@@ -1,0 +1,65 @@
+import { test, beforeEach, expect } from '../../testingFramework';
+import { createGame, setHand, respondWithCard, respondWithNoCards, skipToNextTurn, startGameGetPlayerAndWaitForStartOfTurn, waitForNextInput } from '../../toolbox';
+
+export default () => {
+  let game;
+
+  beforeEach(async () => {
+    game = await createGame();
+    game.getKingdomCards = () => ['Lighthouse'];
+  });
+
+  test('should give money now and later', async () => {
+    const player = await startGameGetPlayerAndWaitForStartOfTurn(game);
+    setHand(player, ['Copper', 'Copper', 'Copper', 'Copper', 'Lighthouse']);
+    await waitForNextInput();
+    respondWithCard('Lighthouse');
+    await waitForNextInput();
+    expect(player.money).toBe(1);
+
+    await skipToNextTurn(player);
+    await waitForNextInput();
+    expect(player.money).toBe(1);
+  });
+
+  test('should block attacks', async () => {
+    const player = await startGameGetPlayerAndWaitForStartOfTurn(game);
+    setHand(player, ['Copper', 'Copper', 'Copper', 'Copper', 'Lighthouse']);
+    const otherPlayer = game.playerOrder.find(p => p !== player);
+    setHand(otherPlayer, ['Copper', 'Copper', 'Copper', 'Silver', 'Militia']);
+    await waitForNextInput();
+    respondWithCard('Lighthouse');
+    await waitForNextInput();
+    expect(player.money).toBe(1);
+
+    await skipToNextTurn(otherPlayer);
+    await waitForNextInput();
+    respondWithCard('Militia');
+    await waitForNextInput();
+    respondWithCard('Silver');
+    expect(player.hand.length).toBe(5);
+  });
+
+  test('shouldn\'t conflit with moat', async () => {
+    const player = await startGameGetPlayerAndWaitForStartOfTurn(game);
+    setHand(player, ['Copper', 'Copper', 'Copper', 'Copper', 'Lighthouse']);
+    const otherPlayer = game.playerOrder.find(p => p !== player);
+    setHand(otherPlayer, ['Copper', 'Copper', 'Copper', 'Silver', 'Militia']);
+    await waitForNextInput();
+    respondWithCard('Lighthouse');
+    await waitForNextInput();
+    expect(player.money).toBe(1);
+
+    await skipToNextTurn(otherPlayer);
+    setHand(player, ['Copper', 'Copper', 'Copper', 'Copper', 'Moat']);
+    await waitForNextInput();
+    respondWithCard('Militia'); // other attacks with militia
+    await waitForNextInput();
+    respondWithCard('Lighthouse');  // player chooses Lighthouse to block the attack
+    await waitForNextInput();
+    respondWithNoCards(); // player declines option to also show Moat
+    await waitForNextInput();
+    respondWithCard('Silver');  // other continues with buy phase
+    expect(player.hand.length).toBe(5);
+  });
+};

--- a/src/tests/server/cards/seaside/Lookout.js
+++ b/src/tests/server/cards/seaside/Lookout.js
@@ -1,0 +1,47 @@
+import { test, beforeEach, expect } from '../../testingFramework';
+import { createGame, setHand, setDeck, respondWithCard, startGameGetPlayerAndWaitForStartOfTurn, waitForNextInput } from '../../toolbox';
+
+export default () => {
+  let game;
+
+  beforeEach(async () => {
+    game = await createGame();
+    game.getKingdomCards = () => ['Lookout'];
+  });
+
+  test('should move cards correctly', async () => {
+    const player = await startGameGetPlayerAndWaitForStartOfTurn(game);
+    setHand(player, ['Copper', 'Copper', 'Copper', 'Copper', 'Lookout']);
+    setDeck(player, ['Copper', 'Copper', 'Province', 'Duchy', 'Estate']);
+    await waitForNextInput();
+    respondWithCard('Lookout');
+    await waitForNextInput();
+    respondWithCard('Estate');
+    await waitForNextInput();
+    respondWithCard('Duchy');
+    await waitForNextInput();
+    respondWithCard('Province');
+    await waitForNextInput();
+    expect(game.trash.last().title).toBe('Estate');
+    expect(player.discardPile.last().title).toBe('Duchy');
+    expect(player.deck.last().title).toBe('Province');
+    expect(player.actions).toBe(1);
+  });
+
+  test('should work with not enough cards in deck', async () => {
+    const player = await startGameGetPlayerAndWaitForStartOfTurn(game);
+    setHand(player, ['Copper', 'Copper', 'Copper', 'Copper', 'Lookout']);
+    setDeck(player, ['Duchy', 'Estate']);
+    await waitForNextInput();
+    respondWithCard('Lookout');
+    await waitForNextInput();
+    respondWithCard('Estate');
+    await waitForNextInput();
+    respondWithCard('Duchy');
+    await waitForNextInput();
+    expect(game.trash.last().title).toBe('Estate');
+    expect(player.discardPile.last().title).toBe('Duchy');
+    expect(player.deck.length).toBe(0);
+    expect(player.actions).toBe(1);
+  });
+};

--- a/src/tests/server/cards/seaside/MerchantShip.js
+++ b/src/tests/server/cards/seaside/MerchantShip.js
@@ -1,0 +1,25 @@
+import { test, beforeEach, expect } from '../../testingFramework';
+import { createGame, setHand, respondWithCard, skipToNextTurn, startGameGetPlayerAndWaitForStartOfTurn, waitForNextInput } from '../../toolbox';
+
+export default () => {
+  let game;
+
+  beforeEach(async () => {
+    game = await createGame();
+    game.getKingdomCards = () => ['MerchantShip'];
+  });
+
+  test('should give $2 now and next turn', async () => {
+    const player = await startGameGetPlayerAndWaitForStartOfTurn(game);
+    setHand(player, ['Copper', 'Copper', 'Copper', 'Copper', 'MerchantShip']);
+    await waitForNextInput();
+    respondWithCard('MerchantShip');
+    await waitForNextInput();
+    expect(player.hand.length).toBe(4);
+    expect(player.money).toBe(2);
+
+    await skipToNextTurn(player);
+    await waitForNextInput();
+    expect(player.money).toBe(2);
+  });
+};

--- a/src/tests/server/cards/seaside/NativeVillage.js
+++ b/src/tests/server/cards/seaside/NativeVillage.js
@@ -1,0 +1,72 @@
+import { test, beforeEach, expect } from '../../testingFramework';
+import { createGame, setHand, setDeck, respondWithCard, respondWithChoice, startGameGetPlayerAndWaitForStartOfTurn, waitForNextInput } from '../../toolbox';
+
+export default () => {
+  let game;
+
+  beforeEach(async () => {
+    game = await createGame();
+    game.getKingdomCards = () => ['NativeVillage'];
+  });
+
+  test('should place on mat', async () => {
+    const player = await startGameGetPlayerAndWaitForStartOfTurn(game);
+    setHand(player, ['Copper', 'Copper', 'Copper', 'Copper', 'NativeVillage']);
+    await waitForNextInput();
+    respondWithCard('NativeVillage');
+    await waitForNextInput();
+    respondWithChoice(0);
+    await waitForNextInput();
+    expect(player.actions).toBe(2);
+    expect(player.mats.nativeVillage.length).toBe(1);
+  });
+
+  test('should pickup from mat', async () => {
+    const player = await startGameGetPlayerAndWaitForStartOfTurn(game);
+    setHand(player, ['Copper', 'Copper', 'Copper', 'NativeVillage', 'NativeVillage']);
+    setDeck(player, ['Copper', 'Copper', 'Copper', 'Copper', 'Gold']);
+    await waitForNextInput();
+    respondWithCard('NativeVillage');
+    await waitForNextInput();
+    respondWithChoice(0);
+    await waitForNextInput();
+    respondWithCard('NativeVillage');
+    await waitForNextInput();
+    respondWithChoice(1);
+    await waitForNextInput();
+    expect(player.actions).toBe(3);
+    expect(player.mats.nativeVillage.length).toBe(0);
+    expect(player.hand.last().title).toBe('Gold');
+  });
+
+  test('shouldn\'t fail with empty deck/mat', async () => {
+    const player = await startGameGetPlayerAndWaitForStartOfTurn(game);
+    setHand(player, ['Copper', 'Copper', 'Copper', 'NativeVillage', 'NativeVillage']);
+    setDeck(player, []);
+    await waitForNextInput();
+    respondWithCard('NativeVillage');
+    await waitForNextInput();
+    respondWithChoice(0);
+    await waitForNextInput();
+    respondWithCard('NativeVillage');
+    await waitForNextInput();
+    respondWithChoice(1);
+    await waitForNextInput();
+    expect(player.actions).toBe(3);
+    expect(player.mats.nativeVillage.length).toBe(0);
+    expect(player.hand.length).toBe(3);
+  });
+
+  test('should find at end of game', async () => {
+    const player = await startGameGetPlayerAndWaitForStartOfTurn(game);
+    setHand(player, ['Copper', 'Copper', 'Copper', 'NativeVillage', 'NativeVillage']);
+    setDeck(player, ['Province']);
+    await waitForNextInput();
+    respondWithCard('NativeVillage');
+    await waitForNextInput();
+    respondWithChoice(0);
+    await waitForNextInput();
+    game.endOfGame();
+    expect(player.score).toBe(6);;
+  });
+};

--- a/src/tests/server/cards/seaside/Navigator.js
+++ b/src/tests/server/cards/seaside/Navigator.js
@@ -1,0 +1,47 @@
+import { test, beforeEach, expect } from '../../testingFramework';
+import { createGame, setHand, setDeck, respondWithCard, respondWithChoice, startGameGetPlayerAndWaitForStartOfTurn, waitForNextInput } from '../../toolbox';
+
+export default () => {
+  let game;
+
+  beforeEach(async () => {
+    game = await createGame();
+    game.getKingdomCards = () => ['Navigator'];
+  });
+
+  test('can discard', async () => {
+    const player = await startGameGetPlayerAndWaitForStartOfTurn(game);
+    setHand(player, ['Copper', 'Copper', 'Copper', 'Copper', 'Navigator']);
+    await waitForNextInput();
+    respondWithCard('Navigator');
+    await waitForNextInput();
+    respondWithChoice(1);
+    await waitForNextInput();
+    expect(player.actions).toBe(0);
+    expect(player.money).toBe(2);
+    expect(player.discardPile.length).toBe(5);
+  });
+
+  test('can rearange and put on top', async () => {
+    const player = await startGameGetPlayerAndWaitForStartOfTurn(game);
+    setHand(player, ['Copper', 'Copper', 'Copper', 'Copper', 'Navigator']);
+    setDeck(player, ['Copper', 'Copper', 'Province', 'Gold', 'Copper']);
+    await waitForNextInput();
+    respondWithCard('Navigator');
+    await waitForNextInput();
+    respondWithChoice(0);
+    await waitForNextInput();
+    respondWithCard('Province');
+    await waitForNextInput();
+    respondWithCard('Copper');
+    await waitForNextInput();
+    respondWithCard('Copper');
+    await waitForNextInput();
+    respondWithCard('Copper');
+    await waitForNextInput();
+    expect(player.actions).toBe(0);
+    expect(player.money).toBe(2);
+    expect(player.discardPile.length).toBe(0);
+    expect(player.deck.last().title).toBe('Gold');
+  });
+};

--- a/src/tests/server/cards/seaside/Outpost.js
+++ b/src/tests/server/cards/seaside/Outpost.js
@@ -1,0 +1,63 @@
+import { test, beforeEach, expect } from '../../testingFramework';
+import { createGame, setHand, setDeck, respondWithCard, respondWithSupply, startGameGetPlayerAndWaitForStartOfTurn, waitForNextInput } from '../../toolbox';
+
+export default () => {
+  let game;
+
+  beforeEach(async () => {
+    game = await createGame();
+    game.getKingdomCards = () => ['Outpost'];
+  });
+
+  test('should give extra turn with three cards', async () => {
+    const player = await startGameGetPlayerAndWaitForStartOfTurn(game);
+    setHand(player, ['Outpost']);
+    setDeck(player, ['Estate', 'Estate', 'Gold', 'Silver', 'Festival']);
+    await waitForNextInput();
+    respondWithCard('Outpost');
+    await waitForNextInput();
+    respondWithSupply('Curse');
+    await waitForNextInput();
+    expect(player.hand.length).toBe(3);
+
+    respondWithCard('Festival');
+    await waitForNextInput();
+    expect(player.playArea.length).toBe(2);
+    respondWithCard('Gold');
+    await waitForNextInput();
+    expect(player.hand.length).toBe(1);
+    expect(player.money).toBe(5);
+  });
+
+  test('second played on a turn doesn\'t stay out or work', async () => {
+    const player = await startGameGetPlayerAndWaitForStartOfTurn(game);
+    setHand(player, ['Outpost', 'Festival', 'Outpost']);
+    setDeck(player, ['Estate', 'Silver', 'Gold', 'Estate', 'Festival']);
+    await waitForNextInput();
+    respondWithCard('Festival');
+    await waitForNextInput();
+    respondWithCard('Outpost');
+    await waitForNextInput();
+    respondWithCard('Outpost');
+    await waitForNextInput();
+    respondWithSupply('Curse');
+    await waitForNextInput();
+    respondWithSupply('Curse');
+    await waitForNextInput();
+    expect(player.hand.length).toBe(3);
+
+    respondWithCard('Festival');
+    await waitForNextInput();
+    expect(player.playArea.length).toBe(2);
+    respondWithCard('Gold');
+    await waitForNextInput();
+    expect(player.hand.length).toBe(1);
+    expect(player.money).toBe(5);
+    respondWithSupply('Curse');
+    await waitForNextInput();
+    respondWithSupply('Curse');
+    await waitForNextInput();
+
+    expect(game.currentPlayer).toNotBe(player);
+  });
+};

--- a/src/tests/server/cards/seaside/PearlDiver.js
+++ b/src/tests/server/cards/seaside/PearlDiver.js
@@ -1,0 +1,39 @@
+import { test, beforeEach, expect } from '../../testingFramework';
+import { createGame, setHand, setDeck, respondWithCard, respondWithChoice, startGameGetPlayerAndWaitForStartOfTurn, waitForNextInput } from '../../toolbox';
+
+export default () => {
+  let game;
+
+  beforeEach(async () => {
+    game = await createGame();
+    game.getKingdomCards = () => ['PearlDiver'];
+  });
+
+  test('should move to top of deck', async () => {
+    const player = await startGameGetPlayerAndWaitForStartOfTurn(game);
+    setHand(player, ['Copper', 'Copper', 'Copper', 'Copper', 'PearlDiver']);
+    setDeck(player, ['Gold', 'Copper', 'Copper', 'Copper', 'Copper']);
+    await waitForNextInput();
+    respondWithCard('PearlDiver');
+    await waitForNextInput();
+    respondWithChoice(0);
+    await waitForNextInput();
+    expect(player.hand.length).toBe(5);
+    expect(player.actions).toBe(1);
+    expect(player.deck.last().title).toBe('Gold');
+  });
+
+  test('should stay if we choose so', async () => {
+    const player = await startGameGetPlayerAndWaitForStartOfTurn(game);
+    setHand(player, ['Copper', 'Copper', 'Copper', 'Copper', 'PearlDiver']);
+    setDeck(player, ['Gold', 'Copper', 'Copper', 'Copper', 'Copper']);
+    await waitForNextInput();
+    respondWithCard('PearlDiver');
+    await waitForNextInput();
+    respondWithChoice(1);
+    await waitForNextInput();
+    expect(player.hand.length).toBe(5);
+    expect(player.actions).toBe(1);
+    expect(player.deck.first().title).toBe('Gold');
+  });
+};

--- a/src/tests/server/cards/seaside/PirateShip.js
+++ b/src/tests/server/cards/seaside/PirateShip.js
@@ -1,0 +1,101 @@
+import { test, beforeEach, expect } from '../../testingFramework';
+import { createGame, setHand, setDeck, respondWithCard, respondWithChoice, startGameGetPlayerAndWaitForStartOfTurn, waitForNextInput } from '../../toolbox';
+
+export default () => {
+  let game;
+
+  beforeEach(async () => {
+    game = await createGame();
+    game.getKingdomCards = () => ['PirateShip'];
+  });
+
+  test('should trash only treasure', async () => {
+    const player = await startGameGetPlayerAndWaitForStartOfTurn(game);
+    setHand(player, ['Copper', 'Copper', 'Copper', 'Copper', 'PirateShip']);
+    const otherPlayer = game.playerOrder.find(p => p !== player);
+    setDeck(otherPlayer, ['Estate', 'Estate', 'Estate', 'Estate', 'Copper']);
+    await waitForNextInput();
+    respondWithCard('PirateShip');
+    await waitForNextInput();
+    respondWithChoice(1);
+    await waitForNextInput();
+    respondWithCard('Copper');
+    await waitForNextInput();
+    expect(player.mats.pirateShip).toBe(1);
+    expect(game.trash.length).toBe(1);
+  });
+
+  test('should allow choice of treasure', async () => {
+    const player = await startGameGetPlayerAndWaitForStartOfTurn(game);
+    setHand(player, ['Copper', 'Copper', 'Copper', 'Copper', 'PirateShip']);
+    const otherPlayer = game.playerOrder.find(p => p !== player);
+    setDeck(otherPlayer, ['Estate', 'Estate', 'Estate', 'Silver', 'Copper']);
+    await waitForNextInput();
+    respondWithCard('PirateShip');
+    await waitForNextInput();
+    respondWithChoice(1);
+    await waitForNextInput();
+    respondWithCard('Silver');
+    await waitForNextInput();
+    expect(player.mats.pirateShip).toBe(1);
+    expect(game.trash.length).toBe(1);
+    expect(game.trash.last().title).toBe('Silver');
+  });
+
+  test('should stack', async () => {
+    const player = await startGameGetPlayerAndWaitForStartOfTurn(game);
+    setHand(player, ['Copper', 'Copper', 'Village', 'PirateShip', 'PirateShip']);
+    const otherPlayer = game.playerOrder.find(p => p !== player);
+    setDeck(otherPlayer, ['Estate', 'Gold', 'Estate', 'Silver', 'Copper']);
+    await waitForNextInput();
+    respondWithCard('Village');
+    await waitForNextInput();
+    respondWithCard('PirateShip');
+    await waitForNextInput();
+    respondWithChoice(1);
+    await waitForNextInput();
+    respondWithCard('Silver');
+    await waitForNextInput();
+    respondWithCard('PirateShip');
+    await waitForNextInput();
+    respondWithChoice(1);
+    await waitForNextInput();
+    respondWithCard('Gold');
+    await waitForNextInput();
+    expect(player.mats.pirateShip).toBe(2);
+    expect(game.trash.length).toBe(2);
+    expect(game.trash.last().title).toBe('Gold');
+  });
+
+  test('should give coin', async () => {
+    const player = await startGameGetPlayerAndWaitForStartOfTurn(game);
+    setHand(player, ['Copper', 'Copper', 'Copper', 'Copper', 'PirateShip']);
+    player.mats.pirateShip = 4;
+    await waitForNextInput();
+    respondWithCard('PirateShip');
+    await waitForNextInput();
+    respondWithChoice(0);
+    await waitForNextInput();
+    expect(player.money).toBe(4);
+  });
+
+  test('should be blocked by Moat', async () => {
+    const player = await startGameGetPlayerAndWaitForStartOfTurn(game);
+    setHand(player, ['Copper', 'Copper', 'Copper', 'Copper', 'PirateShip']);
+    const otherPlayer = game.playerOrder.find(p => p !== player);
+    setHand(otherPlayer, ['Copper', 'Copper', 'Copper', 'Copper', 'Moat']);
+    await waitForNextInput();
+    respondWithCard('PirateShip');
+
+    let { player: inputPlayer, lastInputWasValid } = await waitForNextInput();
+    expect(inputPlayer).toBe(otherPlayer);
+    expect(lastInputWasValid).toBe(true);
+    respondWithCard('Moat');
+
+    ({ player: inputPlayer, lastInputWasValid } = await waitForNextInput());
+    expect(lastInputWasValid).toBe(true);
+
+    expect(otherPlayer.deck.length).toBe(5);
+    expect(game.trash.length).toBe(0);
+  });
+};

--- a/src/tests/server/cards/seaside/Salvager.js
+++ b/src/tests/server/cards/seaside/Salvager.js
@@ -1,0 +1,29 @@
+import { test, beforeEach, expect } from '../../testingFramework';
+import { createGame, setHand, respondWithCard, startGameGetPlayerAndWaitForStartOfTurn, waitForNextInput } from '../../toolbox';
+
+export default () => {
+  let game;
+
+  beforeEach(async () => {
+    game = await createGame();
+    game.getKingdomCards = () => ['Salvager'];
+  });
+
+  test('should give coin and buy', async () => {
+    const player = await startGameGetPlayerAndWaitForStartOfTurn(game);
+    setHand(player, ['Copper', 'Copper', 'Copper', 'Gold', 'Salvager']);
+    await waitForNextInput();
+    respondWithCard('Salvager');
+    await waitForNextInput();
+    respondWithCard('Gold');
+    await waitForNextInput();
+    expect(player.hand.length).toBe(3);
+    expect(player.actions).toBe(0);
+    expect(player.buys).toBe(2);
+    expect(player.money).toBe(6);
+  });
+
+  test('should work with potion cost cards');
+
+  test('should work with debt cost cards');
+};

--- a/src/tests/server/cards/seaside/SeaHag.js
+++ b/src/tests/server/cards/seaside/SeaHag.js
@@ -1,0 +1,43 @@
+import { test, beforeEach, expect } from '../../testingFramework';
+import { createGame, setHand, setDeck, respondWithCard, startGameGetPlayerAndWaitForStartOfTurn, waitForNextInput } from '../../toolbox';
+
+export default () => {
+  let game;
+
+  beforeEach(async () => {
+    game = await createGame();
+    game.getKingdomCards = () => ['SeaHag'];
+  });
+
+  test('should curse top card', async () => {
+    const player = await startGameGetPlayerAndWaitForStartOfTurn(game);
+    setHand(player, ['Copper', 'Copper', 'Copper', 'Copper', 'SeaHag']);
+    const otherPlayer = game.playerOrder.find(p => p !== player);
+    setDeck(otherPlayer, ['Copper', 'Copper', 'Copper', 'Copper', 'Estate']);
+    await waitForNextInput();
+    respondWithCard('SeaHag');
+    await waitForNextInput();
+    expect(otherPlayer.deck.last().title).toBe('Curse');
+    expect(otherPlayer.discardPile.last().title).toBe('Estate');
+  });
+
+  test('should be blocked by Moat', async () => {
+    const player = await startGameGetPlayerAndWaitForStartOfTurn(game);
+    setHand(player, ['Copper', 'Copper', 'Copper', 'Copper', 'Militia']);
+    const otherPlayer = game.playerOrder.find(p => p !== player);
+    setHand(otherPlayer, ['Copper', 'Copper', 'Copper', 'Copper', 'Moat']);
+    await waitForNextInput();
+    respondWithCard('Militia');
+
+    let { player: inputPlayer, lastInputWasValid } = await waitForNextInput();
+    expect(inputPlayer).toBe(otherPlayer);
+    expect(lastInputWasValid).toBe(true);
+    respondWithCard('Moat');
+
+    ({ player: inputPlayer, lastInputWasValid } = await waitForNextInput());
+    expect(lastInputWasValid).toBe(true);
+
+    expect(otherPlayer.deck.length).toBe(5);
+    expect(otherPlayer.discardPile.length).toBe(0);
+  });
+};

--- a/src/tests/server/cards/seaside/Smugglers.js
+++ b/src/tests/server/cards/seaside/Smugglers.js
@@ -1,0 +1,21 @@
+import { test, beforeEach, expect } from '../../testingFramework';
+import { createGame, setHand, skipToNextTurn, respondWithCard, respondWithSupply, startGameGetPlayerAndWaitForStartOfTurn, waitForNextInput } from '../../toolbox';
+
+export default () => {
+  let game;
+
+  beforeEach(async () => {
+    game = await createGame();
+    // game.getKingdomCards = () => ['Smugglers'];
+  });
+
+  test('Card not yet Made');
+
+// should work on Gold
+// shouldn\'t work on Province
+// works if gained or bought
+// works if muptiple cards are gainied
+// works if pile was empties (valid selection but nothing happens)
+// doesn't fail on play if they gained nothing
+// doesn't give option to gain potion/debt cost cards
+};

--- a/src/tests/server/cards/seaside/Tactician.js
+++ b/src/tests/server/cards/seaside/Tactician.js
@@ -1,0 +1,47 @@
+import { test, beforeEach, expect } from '../../testingFramework';
+import { createGame, setHand, setDeck, respondWithCard, startGameGetPlayerAndWaitForStartOfTurn, skipToNextTurn, waitForNextInput } from '../../toolbox';
+
+export default () => {
+  let game;
+
+  beforeEach(async () => {
+    game = await createGame();
+    game.getKingdomCards = () => ['Tactician'];
+  });
+
+  test('should discard and give mega turn', async () => {
+    const player = await startGameGetPlayerAndWaitForStartOfTurn(game);
+    setHand(player, ['Copper', 'Copper', 'Copper', 'Copper', 'Tactician']);
+    setDeck(player, Array(10).fill('Copper'));
+    await waitForNextInput();
+    respondWithCard('Tactician');
+    await waitForNextInput();
+    expect(player.hand.length).toBe(0);
+    
+    await skipToNextTurn(player);
+    await waitForNextInput();
+    expect(player.playArea.length).toBe(1);
+    expect(player.actions).toBe(2);
+    expect(player.hand.length).toBe(10);
+    expect(player.buys).toBe(2);
+  });
+
+  test('shouldn\'t work if nothing to discard', async () => {
+    const player = await startGameGetPlayerAndWaitForStartOfTurn(game);
+    setHand(player, ['Tactician']);
+    setDeck(player, Array(10).fill('Copper'));
+    await waitForNextInput();
+    respondWithCard('Tactician');
+    await waitForNextInput();
+    expect(player.hand.length).toBe(0);
+    
+    await skipToNextTurn(player);
+    await waitForNextInput();
+    expect(player.playArea.length).toBe(0);
+    expect(player.actions).toBe(1);
+    expect(player.hand.length).toBe(5);
+    expect(player.buys).toBe(1);
+  });
+
+  test('Should work with Throne Room'); //throne doesn't stay out since it doesn't work
+};

--- a/src/tests/server/cards/seaside/TreasureMap.js
+++ b/src/tests/server/cards/seaside/TreasureMap.js
@@ -1,0 +1,46 @@
+import { test, beforeEach, expect } from '../../testingFramework';
+import { createGame, setHand, setDeck, respondWithCard, startGameGetPlayerAndWaitForStartOfTurn, waitForNextInput } from '../../toolbox';
+
+export default () => {
+  let game;
+
+  beforeEach(async () => {
+    game = await createGame();
+    game.getKingdomCards = () => ['TreasureMap'];
+  });
+
+  test('should trash and gain gold with second map', async () => {
+    const player = await startGameGetPlayerAndWaitForStartOfTurn(game);
+    setHand(player, ['Copper', 'Copper', 'Copper', 'TreasureMap', 'TreasureMap']);
+    setDeck(player, []);
+    await waitForNextInput();
+    respondWithCard('TreasureMap');
+    await waitForNextInput();
+    expect(player.hand.length).toBe(3);
+    expect(player.deck.filter(c => c.title === 'Gold').length).toBe(4);
+  });
+
+  test('should work with three in hand', async () => {
+    const player = await startGameGetPlayerAndWaitForStartOfTurn(game);
+    setHand(player, ['Copper', 'Copper', 'TreasureMap', 'TreasureMap', 'TreasureMap']);
+    setDeck(player, []);
+    await waitForNextInput();
+    respondWithCard('TreasureMap');
+    await waitForNextInput();
+    expect(player.hand.length).toBe(3);
+    expect(player.deck.filter(c => c.title === 'Gold').length).toBe(4);
+  });
+
+  test('should trash but fail if only map', async () => {
+    const player = await startGameGetPlayerAndWaitForStartOfTurn(game);
+    setHand(player, ['Copper', 'Copper', 'Copper', 'Copper', 'TreasureMap']);
+    setDeck(player, []);
+    await waitForNextInput();
+    respondWithCard('TreasureMap');
+    await waitForNextInput();
+    expect(player.hand.length).toBe(4);
+    expect(player.deck.filter(c => c.title === 'Gold').length).toBe(0);
+  });
+
+  test('Correct interaction with Band of Misfits and Overlord');
+};

--- a/src/tests/server/cards/seaside/Treasury.js
+++ b/src/tests/server/cards/seaside/Treasury.js
@@ -1,0 +1,95 @@
+import { test, beforeEach, expect } from '../../testingFramework';
+import { createGame, setHand, setDeck, respondWithCard, respondWithSupply, startGameGetPlayerAndWaitForStartOfTurn, skipToNextTurn, waitForNextInput } from '../../toolbox';
+
+export default () => {
+  let game;
+
+  beforeEach(async () => {
+    game = await createGame();
+    game.getKingdomCards = () => ['Treasury'];
+  });
+
+  test('should go back into hand', async () => {
+    const player = await startGameGetPlayerAndWaitForStartOfTurn(game);
+    setHand(player, ['Estate', 'Estate', 'Estate', 'Estate', 'Treasury']);
+    setDeck(player, Array(10).fill('Estate'));
+    await waitForNextInput();
+    respondWithCard('Treasury');
+    await waitForNextInput();
+    respondWithSupply('Curse');
+    await waitForNextInput();
+    respondWithCard('Treasury');
+    await waitForNextInput();
+    expect(player.hand.length).toBe(5);
+    expect(player.actions).toBe(1);
+    expect(player.money).toBe(1);
+
+    await skipToNextTurn(player);
+    await waitForNextInput();
+    expect(player.hand.filter(c => c.title === 'Treasury').length).toBe(1);
+  });
+
+  test('should stack', async () => {
+    const player = await startGameGetPlayerAndWaitForStartOfTurn(game);
+    setHand(player, ['Estate', 'Estate', 'Treasury', 'Treasury', 'Treasury']);
+    setDeck(player, Array(10).fill('Estate'));
+    await waitForNextInput();
+    respondWithCard('Treasury');
+    await waitForNextInput();
+    respondWithCard('Treasury');
+    await waitForNextInput();
+    respondWithCard('Treasury');
+    await waitForNextInput();
+    expect(player.hand.length).toBe(5);
+    expect(player.actions).toBe(1);
+    expect(player.money).toBe(3);
+    respondWithSupply('Curse');
+    await waitForNextInput();
+    respondWithCard('Treasury');
+    await waitForNextInput();
+    respondWithCard('Treasury');
+    await waitForNextInput();
+    respondWithCard('Treasury');
+    await waitForNextInput();
+
+    await skipToNextTurn(player);
+    await waitForNextInput();
+    expect(player.hand.filter(c => c.title === 'Treasury').length).toBe(3);
+  });
+
+  test('should be optional', async () => {
+    const player = await startGameGetPlayerAndWaitForStartOfTurn(game);
+    setHand(player, ['Estate', 'Estate', 'Treasury', 'Treasury', 'Treasury']);
+    setDeck(player, Array(10).fill('Estate'));
+    await waitForNextInput();
+    respondWithCard('Treasury');
+    await waitForNextInput();
+    respondWithCard('Treasury');
+    await waitForNextInput();
+    respondWithCard('Treasury');
+    await waitForNextInput();
+    respondWithSupply('Curse');
+    await waitForNextInput();
+
+    await skipToNextTurn(player);
+    await waitForNextInput();
+    expect(player.hand.filter(c => c.title === 'Treasury').length).toBe(0);
+  });
+  test('should not be topdecked if victory card is bought', async () => {
+    const player = await startGameGetPlayerAndWaitForStartOfTurn(game);
+    setHand(player, ['Estate', 'Estate', 'Treasury', 'Treasury', 'Treasury']);
+    setDeck(player, Array(10).fill('Estate'));
+    await waitForNextInput();
+    respondWithCard('Treasury');
+    await waitForNextInput();
+    respondWithCard('Treasury');
+    await waitForNextInput();
+    respondWithCard('Treasury');
+    await waitForNextInput();
+    respondWithSupply('Estate');
+    await waitForNextInput();
+
+    expect(game.currentPlayer).toNotBe(player);
+    expect(player.hand.filter(c => c.title === 'Treasury').length).toBe(0);
+  });
+};

--- a/src/tests/server/cards/seaside/Warehouse.js
+++ b/src/tests/server/cards/seaside/Warehouse.js
@@ -1,0 +1,36 @@
+import { test, beforeEach, expect } from '../../testingFramework';
+import { createGame, setHand, setDeck, respondWithCard, respondWithCards, startGameGetPlayerAndWaitForStartOfTurn, waitForNextInput } from '../../toolbox';
+
+export default () => {
+  let game;
+
+  beforeEach(async () => {
+    game = await createGame();
+    game.getKingdomCards = () => ['Warehouse'];
+  });
+
+  test('works as intended', async () => {
+    const player = await startGameGetPlayerAndWaitForStartOfTurn(game);
+    setHand(player, ['Copper', 'Copper', 'Copper', 'Copper', 'Warehouse']);
+    await waitForNextInput();
+    respondWithCard('Warehouse');
+    await waitForNextInput();
+    respondWithCards(['Copper', 'Copper', 'Copper']);
+    await waitForNextInput();
+    expect(player.hand.length).toBe(4);
+    expect(player.actions).toBe(1);
+  });
+
+  test('works even with a smaller deck than 3', async () => {
+    const player = await startGameGetPlayerAndWaitForStartOfTurn(game);
+    setHand(player, ['Copper', 'Copper', 'Copper', 'Copper', 'Warehouse']);
+    setDeck(player, ['Gold']);
+    await waitForNextInput();
+    respondWithCard('Warehouse');
+    await waitForNextInput();
+    respondWithCards(['Copper', 'Copper', 'Copper']);
+    await waitForNextInput();
+    expect(player.hand.length).toBe(2);
+    expect(player.actions).toBe(1);
+  });
+};

--- a/src/tests/server/cards/seaside/Wharf.js
+++ b/src/tests/server/cards/seaside/Wharf.js
@@ -1,0 +1,26 @@
+import { test, beforeEach, expect } from '../../testingFramework';
+import { createGame, setHand, respondWithCard, skipToNextTurn, startGameGetPlayerAndWaitForStartOfTurn, waitForNextInput } from '../../toolbox';
+
+export default () => {
+  let game;
+
+  beforeEach(async () => {
+    game = await createGame();
+    game.getKingdomCards = () => ['Wharf'];
+  });
+
+  test('should give cards and a buy now and next turn', async () => {
+    const player = await startGameGetPlayerAndWaitForStartOfTurn(game);
+    setHand(player, ['Copper', 'Copper', 'Copper', 'Copper', 'Wharf']);
+    await waitForNextInput();
+    respondWithCard('Wharf');
+    await waitForNextInput();
+    expect(player.hand.length).toBe(6);
+    expect(player.buys).toBe(2);
+
+    await skipToNextTurn(player);
+    await waitForNextInput();
+    expect(player.hand.length).toBe(7);
+    expect(player.buys).toBe(2);
+  });
+};

--- a/src/tests/server/cards/seaside/index.js
+++ b/src/tests/server/cards/seaside/index.js
@@ -1,0 +1,10 @@
+import * as tests from './';
+import { suite } from '../../testingFramework';
+
+delete tests.Index;
+
+suite('Seaside', () => {
+  Object.keys(tests).forEach(testName => {
+    suite(testName, tests[testName]);
+  });
+});

--- a/src/tests/server/tests.js
+++ b/src/tests/server/tests.js
@@ -7,6 +7,7 @@ import './cards/baseSecond';
 import './cards/adventures';
 import './cards/cornucopia';
 import './cards/intrigue';
+import './cards/seaside';
 
 if (process.argv[3]) {
   runTests(new RegExp(process.argv[3].substr(2), 'i'));


### PR DESCRIPTION
Full unit tests for Seaside and Intrigue cards

All work, first and second edition.
I didn't bother pulling them into different folders based on edition, we can clean up later if we care.
Didn't resolve "Name a Card" issues that will arise with split piles, still simply selecting a supply. There will be 5 cards with this issue, all within sets I'm writing. I'll look into them at a later date.